### PR TITLE
update SKILL.md to V2 contract, note consult is browser-only

### DIFF
--- a/LEFTCLAW_SERVICES_SKILL.md
+++ b/LEFTCLAW_SERVICES_SKILL.md
@@ -2,71 +2,98 @@
 # How to interact with the LeftClaw Services marketplace
 
 ## Contract
-- **Address:** `0x24620a968985F97ED9422b7EDFf5970F07906cB7`
+- **Address:** `0xb2fb486a9569ad2c97d9c73936b46ef7fdaa413a` (V2)
 - **Network:** Base (chain 8453)
 - **Owner:** Safe `0x90eF2A9211A3E7CE788561E5af54C76B0Fa3aEd0`
-- **Executor:** `0xa822155c242B3a307086F1e2787E393d78A0B5AC` (clawd-deployer-3)
+- **Treasury:** Safe `0x90eF2A9211A3E7CE788561E5af54C76B0Fa3aEd0`
+- **Workers:** leftclaw, rightclaw, clawdheart, clawdgut, new_worker
 
 ## Frontend
-- **ENS:** `services.clawdbotatg.eth.link`
+- **URL:** `https://leftclaw.services`
+- **ENS:** `leftclaw.services`
 - **IPFS CID:** `bafybeiaa6rwuam6dbeuschagut5ac5djtawd3ayby35urrqsudulfpn7nm`
+
+## Service Types (V2 — dynamic, seeded at deploy, test mode prices)
+| ID | Slug | Name | Price (USDC) |
+|----|------|------|-------------|
+| 1 | consult | Quick Consultation | $0.40 |
+| 2 | consult-deep | Deep Consultation | $0.60 |
+| 3 | pfp | PFP Generator | $0.005 |
+| 4 | audit | Contract Audit | $4.00 |
+| 5 | qa | Frontend QA Audit | $1.00 |
+| 6 | build | Build | $20.00 |
+| 7 | research | Research Report | $2.00 |
+| 8 | judge | Judge / Oracle | $1.00 |
+| 9 | humanqa | HumanQA | $4.00 |
+| 10 | feature | Feature | $10.00 |
+
+Note: Contract is in **test mode** — prices are ~1/50th of production values.
+
+## ⚠️ Consultation Service — Browser Only
+
+**`consult` and `consult-deep` are NOT available via x402 HTTP API.**
+
+Consultation sessions are always conducted in the browser at `https://leftclaw.services`.
+The flow is:
+1. Client posts a `consult` or `consult-deep` job on-chain (via the website or direct contract call)
+2. Contract immediately sets job to `IN_PROGRESS` (consultations auto-start)
+3. Client visits `https://leftclaw.services/jobs/<jobId>` to access their private chat session
+4. Chat is gated by job ownership — client must connect wallet that posted the job
+
+**Do not attempt to call `/api/consult` or `/api/consult-deep` via x402 — these endpoints do not exist.**
+
+## Payment Methods
+- **CLAWD:** `postJob(serviceTypeId, clawdAmount, description)`
+- **USDC:** `postJobWithUsdc(serviceTypeId, description, minClawdOut)` — swaps to CLAWD via Uniswap V3
+- **ETH:** `postJobWithETH(serviceTypeId, description, minClawdOut)` payable — wraps + swaps to CLAWD
+- **CV:** `postJobWithCV(serviceTypeId, cvAmount, description)` — off-chain payment
+- **x402:** Server calls `postJobFor(client, serviceTypeId, description, minClawdOut)` after receiving USDC
+
+## Token Addresses
+- **CLAWD:** `0x9f86dB9fc6f7c9408e8Fda3Ff8ce4e78ac7a6b07`
+- **USDC:** `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+- **WETH:** `0x4200000000000000000000000000000000000006`
+- **Uniswap V3 Router:** `0x2626664c2603336E57B271c5C0b26F421741e481`
 
 ## Key Functions
 
 ### Reading Jobs
 ```bash
 # Total jobs
-cast call 0x24620a968985F97ED9422b7EDFf5970F07906cB7 "getTotalJobs()(uint256)" --rpc-url $RPC
+cast call 0xb2fb486a9569ad2c97d9c73936b46ef7fdaa413a "getTotalJobs()(uint256)" --rpc-url $RPC
 
 # Get job details
-cast call 0x24620a968985F97ED9422b7EDFf5970F07906cB7 "getJob(uint256)((uint256,address,uint8,uint256,uint256,string,uint8,uint256,uint256,uint256,string,address,bool))" 1 --rpc-url $RPC
+cast call 0xb2fb486a9569ad2c97d9c73936b46ef7fdaa413a "getJob(uint256)((uint256,address,uint256,uint256,uint256,string,uint8,uint256,uint256,uint256,string,address,bool,uint8,uint256,string))" <JOB_ID> --rpc-url $RPC
 
 # Open jobs
-cast call 0x24620a968985F97ED9422b7EDFf5970F07906cB7 "getOpenJobs()(uint256[])" --rpc-url $RPC
+cast call 0xb2fb486a9569ad2c97d9c73936b46ef7fdaa413a "getOpenJobs()(uint256[])" --rpc-url $RPC
+
+# All service types
+cast call 0xb2fb486a9569ad2c97d9c73936b46ef7fdaa413a "getAllServiceTypes()((uint256,string,string,uint256,uint256,string)[])" --rpc-url $RPC
 ```
 
-### Accepting Jobs (as executor)
+### Accepting Jobs (as worker)
 ```bash
-cast send 0x24620a968985F97ED9422b7EDFf5970F07906cB7 "acceptJob(uint256)" <JOB_ID> --account clawd-deployer-3 --password "$PASS" --rpc-url $RPC
+cast send 0xb2fb486a9569ad2c97d9c73936b46ef7fdaa413a "acceptJob(uint256)" <JOB_ID> --account <worker-keystore> --password "$PASS" --rpc-url $RPC
 ```
 
-### Completing Jobs (as executor)
+### Completing Jobs (as worker)
 ```bash
-cast send 0x24620a968985F97ED9422b7EDFf5970F07906cB7 "completeJob(uint256,string)" <JOB_ID> "<RESULT_CID>" --account clawd-deployer-3 --password "$PASS" --rpc-url $RPC
+cast send 0xb2fb486a9569ad2c97d9c73936b46ef7fdaa413a "completeJob(uint256,string)" <JOB_ID> "<RESULT_CID>" --account <worker-keystore> --password "$PASS" --rpc-url $RPC
 ```
 
-### Claiming Payment (after 7-day window)
-```bash
-cast send 0x24620a968985F97ED9422b7EDFf5970F07906cB7 "claimPayment(uint256)" <JOB_ID> --account clawd-deployer-3 --password "$PASS" --rpc-url $RPC
-```
+## Job Lifecycle (V2)
+1. **OPEN** — Client posts job, CLAWD escrowed in contract
+2. **IN_PROGRESS** — Worker accepts; CLAWD transferred to treasury immediately (no dispute window)
+3. **COMPLETED** — Worker submits result CID
 
-## Service Types
-| ID | Name | CLAWD Price |
-|----|------|------------|
-| 0 | Quick Consult | 66,666 |
-| 1 | Deep Consult | 100,000 |
-| 2 | Simple Build | 1,666,666 |
-| 3 | Standard Build | 3,333,333 |
-| 4 | Complex Build | 5,000,000 |
-| 5 | Enterprise Build | 8,333,333 |
-| 6 | QA Report | 666,666 |
-| 7 | Contract Audit | 1,000,000 |
-| 8 | Multi-Contract Audit | 2,000,000 |
-| 9 | Custom | Set by poster |
-
-## Job Lifecycle
-1. **OPEN** — Client posts job, CLAWD escrowed
-2. **IN_PROGRESS** — Executor accepts
-3. **COMPLETED** — Executor delivers with result CID
-4. **7-day dispute window** — Client can dispute
-5. **Payment claimed** — After window, executor claims (minus 5% fee)
+Note: V2 has **no dispute window and no protocol fee**. Payment is final on acceptance.
+Consultations skip OPEN and go straight to IN_PROGRESS on creation.
 
 ## Workflow for LeftClaw Bot
-When a job appears:
-1. Check `getOpenJobs()` periodically
-2. Read job description from `descriptionCID`
-3. Accept with `acceptJob(jobId)`
-4. Do the work
+1. Poll `getOpenJobs()` periodically
+2. Read job description from `jobs[id].description`
+3. Accept with `acceptJob(jobId)` — this transfers payment to treasury
+4. Do the work based on `serviceTypeId`
 5. Upload result to IPFS
 6. Complete with `completeJob(jobId, resultCID)`
-7. Wait 7 days, then `claimPayment(jobId)`

--- a/audits/AUDIT-REPORT-FINAL.md
+++ b/audits/AUDIT-REPORT-FINAL.md
@@ -1,0 +1,203 @@
+# LeftClawServices.sol — Full Security Audit Report
+
+**Date**: 2026-03-03
+**Auditor**: clawdhead (clawdadglm)
+**Contract**: `0x24620a968985F97ED9422b7EDFf5970F07906cB7` on Base
+**Source**: [github.com/clawdbotatg/leftclaw-services](https://github.com/clawdbotatg/leftclaw-services)
+
+---
+
+## Executive Summary
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| **CRITICAL** | 0 | — |
+| **HIGH** | 1 | 🔴 Must Fix |
+| **MEDIUM** | 2 | 🟡 Should Fix |
+| **LOW** | 2 | 🟢 Nice to Have |
+| **INFO** | 3 | ℹ️ Consider |
+
+**Recommendation**: Fix HIGH-1 before accepting any significant job deposits. MEDIUM issues should be addressed before production scale.
+
+---
+
+## HIGH-1: withdrawStuckTokens Can Drain Active Job Funds
+
+**Severity**: HIGH  
+**Category**: Access Control / Fund Safety  
+**Location**: `withdrawStuckTokens()` line ~290
+
+**Description**:  
+The `withdrawStuckTokens` function allows the owner to withdraw the **entire balance** of any token, including CLAWD. The contract holds CLAWD for:
+- Open jobs (waiting for executor)
+- In-progress jobs
+- Completed jobs (in dispute window)
+- Unclaimed payments
+
+If the owner calls `withdrawStuckTokens(CLAWD, ...)`, all user funds are drained and executors cannot claim their payments.
+
+**Proof of Concept**:
+```
+1. Client posts job with 1000 CLAWD → contract receives 1000 CLAWD
+2. Executor accepts and completes the job
+3. Owner (malicious or compromised Safe signer) calls withdrawStuckTokens(CLAWD, owner)
+4. All CLAWD transferred to owner
+5. Executor calls claimPayment() → REVERT (insufficient balance)
+```
+
+**Recommendation**:
+```solidity
+function withdrawStuckTokens(address token, address to) external onlyOwner nonReentrant {
+    require(to != address(0), "Zero address");
+    require(token != address(clawdToken), "Cannot withdraw CLAWD - use withdrawProtocolFees");
+    uint256 balance = IERC20(token).balanceOf(address(this));
+    require(balance > 0, "No tokens to withdraw");
+    IERC20(token).safeTransfer(to, balance);
+}
+```
+
+---
+
+## MEDIUM-1: Fee Calculation Inconsistency on Fee Change
+
+**Severity**: MEDIUM  
+**Category**: Accounting  
+**Location**: `completeJob()`, `claimPayment()`, `resolveDispute()`
+
+**Description**:  
+The protocol fee is calculated at two different times with potentially different `protocolFeeBps` values:
+1. `completeJob()`: fee calculated and added to `accumulatedFees`
+2. `claimPayment()`: fee recalculated for payout
+3. `resolveDispute()`: fee recalculated
+
+If owner changes `protocolFeeBps` between completion and claim, accounting breaks.
+
+**Proof of Concept**:
+```
+1. Job completes with 5% fee: accumulatedFees += 50 CLAWD
+2. Owner changes fee to 10%
+3. Executor claims: recalc fee = 100 CLAWD, payout = 900 CLAWD
+4. Owner withdraws fees: gets 50 CLAWD (what accumulatedFees says)
+5. 50 CLAWD stuck in contract (accounting mismatch)
+```
+
+**Recommendation**: Store fee at completion time:
+```solidity
+struct Job {
+    // ... existing fields
+    uint256 protocolFee; // Fee recorded at completion
+}
+```
+
+---
+
+## MEDIUM-2: No Approve Flow in Frontend
+
+**Severity**: MEDIUM  
+**Category**: Frontend UX / Breaking Flow  
+**Location**: `packages/nextjs/app/post/page.tsx`
+
+**Description**:  
+Post job page doesn't check CLAWD allowance or show approve button. Shows error alert directing users to Debug page instead.
+
+Per ethskills.com/frontend-ux: "Four-State Flow — Connect → Network → Approve → Action"
+
+**Recommendation**: Add proper approve flow with `useScaffoldReadContract` to check allowance and `useScaffoldWriteContract` to approve.
+
+---
+
+## LOW-1: No Pause Mechanism
+
+**Severity**: LOW  
+**Category**: Emergency Controls  
+**Location**: Contract-wide
+
+**Description**: No emergency pause. If a critical bug is discovered, no way to halt operations.
+
+**Recommendation**: Add OpenZeppelin Pausable.
+
+---
+
+## LOW-2: No Network Switch Prompt
+
+**Severity**: LOW  
+**Category**: Frontend UX  
+**Location**: `packages/nextjs/app/post/page.tsx`
+
+**Description**: No network switch prompt if user is on wrong chain.
+
+**Recommendation**: Add `useSwitchChain` check for Base mainnet.
+
+---
+
+## INFO-1: View Functions Unbounded Loops
+
+**Severity**: INFO  
+**Location**: `getOpenJobs()`, `getJobsByStatus()`, `getJobsByClient()`
+
+O(n) loops. Acceptable for off-chain RPC calls. For scale, use event-based indexing.
+
+---
+
+## INFO-2: Description CID Not Validated
+
+**Severity**: INFO  
+**Location**: `postJob()`, `postJobCustom()`
+
+Only checks `bytes(descriptionCID).length > 0`. Doesn't validate it's a valid IPFS CID. Acceptable — invalid CIDs just won't resolve.
+
+---
+
+## INFO-3: Hardcoded Uniswap Pool Fees
+
+**Severity**: INFO  
+**Location**: `postJobWithUsdc()` line ~140
+
+Swap path hardcodes pool fees (500 for USDC/WETH, 10000 for WETH/CLAWD). If pools don't exist or have different fees, swaps fail.
+
+---
+
+## Tests Reviewed
+
+The test suite (`LeftClawServices.t.sol`) covers:
+- ✅ Post job with CLAWD
+- ✅ Accept job (executor only)
+- ✅ Complete and claim after dispute window
+- ✅ Cannot claim during dispute window
+- ✅ Dispute and refund
+- ✅ Dispute and release to executor
+- ✅ Cancel open job
+- ✅ Custom job with min 1 CLAWD
+- ✅ Fuzz test for custom amounts
+- ✅ Fee withdrawal
+- ⚠️ Missing: fee change scenario, withdrawStuckTokens CLAWD test
+
+**Missing Tests**:
+1. Fee calculation when `protocolFeeBps` changes mid-job
+2. `withdrawStuckTokens` should fail for CLAWD (or not Drain job funds)
+3. USDC swap path with invalid pool fees
+
+---
+
+## Files Generated
+
+- `/audits/findings-manual.md` — Contract issues
+- `/audits/findings-frontend.md` — Frontend issues
+- `/audits/findings-dos.md` — DoS analysis
+
+---
+
+## Action Items
+
+**Before accepting deposits:**
+1. 🔴 Fix HIGH-1: Block CLAWD from `withdrawStuckTokens`
+
+**Before production scale:**
+2. 🟡 Fix MEDIUM-1: Store fee at completion time
+3. 🟡 Fix MEDIUM-2: Add proper approve flow in frontend
+4. 🟢 Add Pausable emergency switch
+5. 🟢 Add network switch prompt
+
+---
+
+*Audit complete. Ready for review and fixes.*

--- a/audits/findings-dos.md
+++ b/audits/findings-dos.md
@@ -1,0 +1,37 @@
+# DoS Audit Findings — LeftClawServices.sol
+
+## [Info-1] Unbounded Loops in View Functions
+**Severity**: Info
+**Category**: evm-audit-dos
+**Location**: `getOpenJobs()`, `getJobsByStatus()`, `getJobsByClient()`
+
+**Description**: These functions loop through all jobs to filter by status or client. As job count grows into thousands, these calls could hit block gas limits if called on-chain. However, they are view functions intended for off-chain RPC calls which are free.
+
+**Proof of Concept**: Deploy contract, create 10,000+ jobs, call `getOpenJobs()` on-chain.
+
+**Recommendation**: Acceptable for v1. For scale, implement event-based indexing off-chain instead of on-chain filtering. Events `JobPosted`, `JobAccepted`, etc. are already emitted — index those.
+
+---
+
+## [Info-2] No Pagination for Job Lists
+**Severity**: Info
+**Category**: evm-audit-dos
+**Location**: All view functions returning job arrays
+
+**Description**: No pagination mechanism for large result sets. If job count grows large, even off-chain calls could be slow.
+
+**Recommendation**: Add `getJobsPaginated(uint256 offset, uint256 limit)` for frontend use. Low priority — current approach works for early-stage usage.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High | 0 |
+| Medium | 0 |
+| Low | 0 |
+| Info | 2 |
+
+View function loops are the only concern. They're acceptable for off-chain use but should be replaced with event-based indexing at scale.

--- a/audits/findings-frontend.md
+++ b/audits/findings-frontend.md
@@ -1,0 +1,128 @@
+# Frontend QA Findings — LeftClawServices
+
+**Date**: 2026-03-03
+**Auditor**: clawdhead (clawdadglm)
+
+---
+
+## [MEDIUM-FE-1] Missing Approve Flow in Post Job Page
+
+**Severity**: Medium (UX / Breaking Flow)  
+**Category**: Frontend UX  
+**Location**: `packages/nextjs/app/post/page.tsx`
+
+**Description**:  
+The post job page does not proactively check CLAWD allowance and show an approve button. Instead, it catches the "insufficient allowance" error and shows an alert telling users to go to the Debug page.
+
+Per ethskills.com/frontend-ux, every token interaction needs a proper approve flow:
+> **Four-State Flow — Connect → Network → Approve → Action**
+> Show exactly ONE big button at a time:
+> 3. Not enough approved? → "Approve" button (with loader)
+
+**Current Code**:
+```tsx
+const handlePost = async () => {
+  try {
+    setStep("post");
+    await postAsync({ functionName: "postJob", args: [...] });
+  } catch (e: any) {
+    if (e?.message?.includes("insufficient allowance")) {
+      alert("You need to approve CLAWD spending first. Visit the Debug page...");
+    }
+  }
+};
+```
+
+**Expected Behavior**:
+1. Read user's CLAWD allowance for the contract
+2. If allowance < price: show "Approve CLAWD" button
+3. After approval confirms: show "Post Job" button
+4. Each button has its own loading state
+
+**Recommendation**:
+```tsx
+const { data: allowance } = useScaffoldReadContract({
+  contractName: "CLAWD", // from externalContracts
+  functionName: "allowance",
+  args: [address, LEFTCLAW_SERVICES_ADDRESS],
+});
+
+const { writeContractAsync: approveAsync } = useScaffoldWriteContract("CLAWD");
+
+const needsApproval = allowance ? allowance < priceWei : true;
+
+// Then in UI:
+if (!address) {
+  return <ConnectWalletButton />;
+}
+
+if (needsApproval) {
+  return (
+    <button 
+      onClick={handleApprove}
+      disabled={step === "approve"}
+      className={step === "approve" ? "loading" : ""}
+    >
+      {step === "approve" ? "Approving..." : "Approve CLAWD"}
+    </button>
+  );
+}
+
+return (
+  <button onClick={handlePost} disabled={step === "post"}>
+    {step === "post" ? "Posting..." : "Post Job 🦞"}
+  </button>
+);
+```
+
+---
+
+## [LOW-FE-1] No Network Switch Prompt
+
+**Severity**: Low  
+**Category**: Frontend UX  
+**Location**: `packages/nextjs/app/post/page.tsx`
+
+**Description**:  
+The app is deployed on Base mainnet, but there's no network switch prompt if the user is on a different chain.
+
+**Recommendation**:  
+Add network switch check:
+```tsx
+import { useSwitchChain } from "wagmi";
+import { base } from "viem/chains";
+
+const { chain } = useAccount();
+const { switchChain } = useSwitchChain();
+
+if (chain?.id !== base.id) {
+  return (
+    <button onClick={() => switchChain({ chainId: base.id })}>
+      Switch to Base
+    </button>
+  );
+}
+```
+
+---
+
+## [INFO-FE-1] No Loading State for Price fetch
+
+**Severity**: Info  
+**Category**: Frontend UX  
+**Location**: `packages/nextjs/app/page.tsx` and `app/post/page.tsx`
+
+**Description**:  
+The price display shows "..." while loading, but there's no skeleton or loading indicator. This is acceptable but could be improved.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Medium | 1 |
+| Low | 1 |
+| Info | 1 |
+
+**Priority**: Fix the approve flow (MEDIUM-FE-1) before users try to post jobs.

--- a/audits/findings-manual.md
+++ b/audits/findings-manual.md
@@ -1,0 +1,156 @@
+# Manual Audit Findings — LeftClawServices.sol
+
+**Date**: 2026-03-03
+**Auditor**: clawdhead (clawdadglm)
+
+---
+
+## [HIGH-1] withdrawStuckTokens Can Drain Active Job Funds
+
+**Severity**: High  
+**Category**: Access Control / Fund Safety  
+**Location**: `withdrawStuckTokens()` line 290
+
+**Description**:  
+The `withdrawStuckTokens` function allows the owner to withdraw the **entire balance** of any token, including CLAWD. However, the contract holds CLAWD for:
+- Open jobs (waiting for executor)
+- In-progress jobs
+- Completed jobs (in dispute window)
+- Unclaimed payments
+
+If the owner calls `withdrawStuckTokens(CLAWD, ...)`, all user funds are drained and executors cannot claim their payments.
+
+**Proof of Concept**:
+1. Client posts a job with 1000 CLAWD
+2. Executor accepts and completes the job
+3. Owner (malicious or compromised) calls `withdrawStuckTokens(CLAWD, owner)`
+4. All CLAWD is transferred to owner
+5. Executor tries to `claimPayment()` → transaction reverts due to insufficient balance
+
+**Recommendation**:
+```solidity
+function withdrawStuckTokens(address token, address to) external onlyOwner nonReentrant {
+    require(to != address(0), "Zero address");
+    require(token != address(clawdToken), "Cannot withdraw CLAWD");
+    uint256 balance = IERC20(token).balanceOf(address(this));
+    require(balance > 0, "No tokens to withdraw");
+    IERC20(token).safeTransfer(to, balance);
+}
+```
+
+Or, track claimable CLAWD separately and only allow withdrawal of excess:
+```solidity
+uint256 public lockedClawd; // Total CLAWD locked in active jobs
+
+function withdrawStuckTokens(address token, address to) external onlyOwner nonReentrant {
+    require(to != address(0), "Zero address");
+    uint256 balance = IERC20(token).balanceOf(address(this));
+    if (token == address(clawdToken)) {
+        uint256 withdrawable = balance - lockedClawd - accumulatedFees;
+        require(withdrawable > 0, "No withdrawable CLAWD");
+        IERC20(token).safeTransfer(to, withdrawable);
+    } else {
+        require(balance > 0, "No tokens to withdraw");
+        IERC20(token).safeTransfer(to, balance);
+    }
+}
+```
+
+---
+
+## [MEDIUM-1] Fee Calculation Inconsistency on Fee Change
+
+**Severity**: Medium  
+**Category**: Accounting / Precision  
+**Location**: `completeJob()`, `claimPayment()`, `resolveDispute()`
+
+**Description**:  
+The protocol fee is calculated at two different times with potentially different `protocolFeeBps` values:
+
+1. In `completeJob()`: fee is calculated and added to `accumulatedFees`
+2. In `claimPayment()`: fee is recalculated for payout
+3. In `resolveDispute()`: fee is recalculated for refund/release
+
+If the owner changes `protocolFeeBps` between completion and claim, the fee recorded in `accumulatedFees` won't match the actual fee deducted.
+
+**Proof of Concept**:
+1. Job completes with 5% fee (500 bps): `accumulatedFees += 50 CLAWD`
+2. Owner changes fee to 10% (1000 bps)
+3. Executor claims: recalculated fee = 100 CLAWD, payout = 900 CLAWD
+4. `accumulatedFees` records 50, but 100 CLAWD stays in contract as fee
+5. Owner calls `withdrawProtocolFees()` → withdraws 50 CLAWD
+6. 50 CLAWD remains stuck in contract (accounting mismatch)
+
+**Recommendation**:
+Store the fee at completion time in the Job struct:
+```solidity
+struct Job {
+    // ... existing fields
+    uint256 protocolFee; // Fee recorded at completion
+}
+
+function completeJob(uint256 jobId, string calldata resultCID) external nonReentrant onlyExecutor {
+    // ...
+    uint256 fee = (job.paymentClawd * protocolFeeBps) / 10_000;
+    job.protocolFee = fee;
+    accumulatedFees += fee;
+    // ...
+}
+
+function claimPayment(uint256 jobId) external nonReentrant {
+    // ...
+    uint256 payout = job.paymentClawd - job.protocolFee; // Use stored fee
+    // ...
+}
+```
+
+---
+
+## [LOW-1] No Pause Mechanism
+
+**Severity**: Low  
+**Category**: Emergency Controls  
+**Location**: Contract-wide
+
+**Description**:  
+The contract has no emergency pause mechanism. If a critical bug is discovered, there's no way to halt job posting, acceptance, or payments.
+
+**Recommendation**:  
+Add Pausable from OpenZeppelin:
+```solidity
+import "@openzeppelin/contracts/utils/Pausable.sol";
+
+contract LeftClawServices is Ownable, ReentrancyGuard, Pausable {
+    function postJob(...) external nonReentrant whenNotPaused { ... }
+    function acceptJob(...) external nonReentrant onlyExecutor whenNotPaused { ... }
+    // etc.
+    
+    function pause() external onlyOwner {
+        _pause();
+    }
+    
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}
+```
+
+---
+
+## [INFO-1] View Functions Unbounded Loops
+
+Already documented in `findings-dos.md` — O(n) loops in `getOpenJobs`, `getJobsByStatus`, `getJobsByClient`. Acceptable for off-chain use.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| **Critical** | 0 |
+| **High** | 1 |
+| **Medium** | 1 |
+| **Low** | 1 |
+| **Info** | 1 |
+
+**Recommendation**: Fix HIGH-1 before any significant funds are deposited. MEDIUM-1 should be fixed to ensure correct accounting. LOW-1 is recommended for production.

--- a/audits/findings-precision-math.md
+++ b/audits/findings-precision-math.md
@@ -1,0 +1,271 @@
+# Precision & Math Audit — LeftClawServices.sol
+
+**Auditor**: evm-audit-precision-math  
+**Date**: 2026-03-03  
+**Contract**: `LeftClawServices.sol` (Solidity ^0.8.20)  
+**Scope**: All arithmetic, fee calculations, token amount handling, precision/rounding concerns.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0     |
+| High     | 1     |
+| Medium   | 3     |
+| Low      | 2     |
+| Info     | 3     |
+| **Total**| **9** |
+
+---
+
+## [high-1] Fee recalculation on dispute refund can underflow `accumulatedFees` if `protocolFeeBps` changed
+
+**Severity**: High  
+**Category**: evm-audit-precision-math  
+**Location**: `resolveDispute()` (line ~191), `completeJob()` (line ~157)
+
+**Description**: When a job is completed in `completeJob()`, the protocol fee is calculated and added to `accumulatedFees`:
+
+```solidity
+uint256 fee = (job.paymentClawd * protocolFeeBps) / 10_000;
+accumulatedFees += fee;
+```
+
+When a dispute is resolved in favor of the client (`refundClient = true`), the fee is recalculated and subtracted:
+
+```solidity
+uint256 fee = (job.paymentClawd * protocolFeeBps) / 10_000;
+accumulatedFees -= fee;
+```
+
+If the owner changes `protocolFeeBps` between `completeJob()` and `resolveDispute()`, the recalculated fee will differ from the originally accumulated fee. If the new fee is larger than what was originally accumulated, `accumulatedFees -= fee` will **revert** due to underflow (Solidity 0.8+), permanently bricking dispute resolution for that job. If the new fee is smaller, the protocol keeps "phantom fees" that aren't backed by actual tokens.
+
+**Proof of Concept**:
+1. Job posted with `paymentClawd = 1_000_000e18`, `protocolFeeBps = 500` (5%).
+2. Executor completes job → `fee = 50_000e18`, `accumulatedFees += 50_000e18`.
+3. Owner calls `setProtocolFee(1000)` (10%).
+4. Client disputes. Owner calls `resolveDispute(jobId, true)`.
+5. `fee = 100_000e18`. `accumulatedFees -= 100_000e18` → **underflow revert**.
+6. Dispute can never be resolved for this job. Client funds locked forever.
+
+**Recommendation**: Store the fee at completion time in the Job struct, so the same value is used for both accumulation and reversal.
+
+```solidity
+// In Job struct, add:
+uint256 feeAtCompletion;
+
+// In completeJob():
+uint256 fee = (job.paymentClawd * protocolFeeBps) / 10_000;
+job.feeAtCompletion = fee;
+accumulatedFees += fee;
+
+// In resolveDispute() refund path:
+accumulatedFees -= job.feeAtCompletion;
+
+// In claimPayment():
+uint256 payout = job.paymentClawd - job.feeAtCompletion;
+```
+
+---
+
+## [medium-1] Fee double-calculation allows payout mismatch if `protocolFeeBps` changes between complete and claim
+
+**Severity**: Medium  
+**Category**: evm-audit-precision-math  
+**Location**: `completeJob()` (line ~157), `claimPayment()` (line ~165)
+
+**Description**: `completeJob()` calculates and accumulates the fee. `claimPayment()` independently recalculates the fee to determine the executor payout. If `protocolFeeBps` changes between these two calls, the fee accumulated in `completeJob()` and the fee deducted in `claimPayment()` will differ. This causes either:
+
+- **Fee increase**: Executor receives less than expected; protocol over-collects (more fees accumulated than deducted from payout).
+- **Fee decrease**: Executor receives more than expected; protocol under-collects. The contract may not have enough CLAWD to cover all obligations.
+
+This is closely related to high-1 but affects the normal (non-dispute) payment path.
+
+**Proof of Concept**:
+1. Job with `paymentClawd = 1_000_000e18`, `protocolFeeBps = 500`.
+2. `completeJob()`: fee = 50,000e18 accumulated.
+3. Owner changes fee to `200` (2%).
+4. After dispute window, executor calls `claimPayment()`: fee = 20,000e18, payout = 980,000e18.
+5. Only 50,000e18 was reserved as fees but 980,000e18 paid out = 1,030,000e18 total outflow vs 1,000,000e18 escrowed. Protocol is 30,000e18 short.
+
+**Recommendation**: Same as high-1 — store `feeAtCompletion` in the Job struct and use it consistently in `claimPayment()` and `resolveDispute()`.
+
+---
+
+## [medium-2] `withdrawStuckTokens()` can drain escrowed CLAWD, breaking all active job payouts
+
+**Severity**: Medium  
+**Category**: evm-audit-precision-math  
+**Location**: `withdrawStuckTokens()` (line ~221)
+
+**Description**: This function transfers the **entire balance** of any token from the contract. If called with the CLAWD token address, it will withdraw all CLAWD — including amounts escrowed for active jobs and accumulated protocol fees. This is not strictly a precision/math bug but directly impacts token amount accounting: after calling this, `accumulatedFees` and job `paymentClawd` values no longer correspond to real balances. All subsequent `claimPayment()`, `cancelJob()`, and `resolveDispute()` calls will revert due to insufficient balance.
+
+**Proof of Concept**:
+1. Multiple active jobs with escrowed CLAWD totaling 10,000,000e18.
+2. Owner calls `withdrawStuckTokens(clawdToken, ownerAddress)`.
+3. All 10,000,000e18 CLAWD drained.
+4. Any `claimPayment()` or `cancelJob()` reverts — funds lost.
+
+**Recommendation**: Exclude CLAWD (and USDC during swaps) from `withdrawStuckTokens()`, or track escrowed totals and only allow withdrawing the excess:
+
+```solidity
+function withdrawStuckTokens(address token, address to) external onlyOwner nonReentrant {
+    require(to != address(0), "Zero address");
+    require(token != address(clawdToken), "Cannot withdraw escrowed CLAWD");
+    uint256 balance = IERC20(token).balanceOf(address(this));
+    require(balance > 0, "No tokens to withdraw");
+    IERC20(token).safeTransfer(to, balance);
+}
+```
+
+---
+
+## [medium-3] Rounding direction in fee calculation favors the executor (rounds fee down)
+
+**Severity**: Medium  
+**Category**: evm-audit-precision-math  
+**Location**: `completeJob()`, `claimPayment()`, `resolveDispute()`
+
+**Description**: The fee calculation uses standard Solidity truncation (rounds toward zero):
+
+```solidity
+uint256 fee = (job.paymentClawd * protocolFeeBps) / 10_000;
+```
+
+This rounds the fee **down**, meaning the protocol always receives ≤ the exact fee, and the executor receives ≥ their exact share. Per the precision math checklist, fee collection should round **up** to favor the protocol. While the magnitude is small (at most 1 wei per fee calculation), this systematically leaks value from the protocol over many jobs.
+
+**Proof of Concept**: For any `paymentClawd` where `(paymentClawd * protocolFeeBps) % 10_000 != 0`, the protocol loses 1 wei on the fee. Over thousands of jobs this compounds.
+
+**Recommendation**: Use rounding-up division for fee calculations:
+
+```solidity
+uint256 fee = (job.paymentClawd * protocolFeeBps + 9_999) / 10_000;
+// Or using OpenZeppelin Math.ceilDiv:
+uint256 fee = Math.ceilDiv(job.paymentClawd * protocolFeeBps, 10_000);
+```
+
+---
+
+## [low-1] No minimum payment validation for USDC-funded jobs after swap
+
+**Severity**: Low  
+**Category**: evm-audit-precision-math  
+**Location**: `postJobWithUsdc()` (line ~128)
+
+**Description**: When paying with USDC, the received CLAWD amount from the Uniswap swap becomes the job's `paymentClawd`. The `minClawdOut` parameter protects against slippage, but there's no minimum CLAWD amount enforced for the job itself. If the caller sets `minClawdOut = 0` or very low, they could create a job with nearly zero CLAWD payment. The `postJobCustom()` function enforces `clawdAmount >= 1e18`, but `postJobWithUsdc()` has no equivalent check on `clawdReceived`.
+
+Also, for standard `ServiceType` (non-CUSTOM) jobs posted via USDC, there is no validation that the swapped CLAWD amount meets the `servicePriceInClawd` for that service type. A user could post a `BUILD_XL` job by paying a tiny amount of USDC.
+
+**Proof of Concept**:
+1. Call `postJobWithUsdc(ServiceType.BUILD_XL, cid, 1, 0)` — 1 wei of USDC, min 0 CLAWD out.
+2. Swap yields ~0 CLAWD (or whatever dust the pool returns).
+3. Job is created as `BUILD_XL` with negligible payment.
+
+**Recommendation**: After the swap, enforce that `clawdReceived` meets the service price for non-CUSTOM types:
+
+```solidity
+if (serviceType != ServiceType.CUSTOM) {
+    require(clawdReceived >= servicePriceInClawd[serviceType], "Insufficient CLAWD after swap");
+} else {
+    require(clawdReceived >= 1e18, "Min 1 CLAWD");
+}
+```
+
+---
+
+## [low-2] Unbounded loop in view functions could cause gas limit issues
+
+**Severity**: Low  
+**Category**: evm-audit-precision-math  
+**Location**: `_getJobsByStatus()`, `getJobsByClient()`
+
+**Description**: These functions iterate over all job IDs from 1 to `nextJobId`. As jobs accumulate, these loops grow unboundedly. While they are `view` functions (no state changes), they can still hit gas limits when called from other contracts or via `eth_call` with gas caps. This isn't a precision math issue per se, but the loop counter `i` uses `uint256` which is fine — no overflow risk.
+
+**Proof of Concept**: After 100,000+ jobs, calling `getOpenJobs()` from another contract may exceed block gas limit.
+
+**Recommendation**: Add pagination (offset + limit parameters) or maintain separate lists/sets per status. For offchain queries, use events and indexing instead.
+
+---
+
+## [info-1] Fee calculation does not suffer from division-before-multiplication
+
+**Severity**: Info  
+**Category**: evm-audit-precision-math  
+**Location**: `completeJob()`, `claimPayment()`, `resolveDispute()`
+
+**Description**: The fee formula `(job.paymentClawd * protocolFeeBps) / 10_000` correctly multiplies before dividing. No division-before-multiplication issue exists here.
+
+---
+
+## [info-2] No unchecked blocks, downcasts, or assembly — overflow/underflow vectors minimal
+
+**Severity**: Info  
+**Category**: evm-audit-precision-math  
+**Location**: Entire contract
+
+**Description**: The contract uses Solidity ^0.8.20 with no `unchecked` blocks, no inline assembly, no downcasts from `uint256` to smaller types, and no signed integer arithmetic. All arithmetic operations benefit from built-in overflow/underflow protection. The only underflow risk is the `accumulatedFees -= fee` in `resolveDispute()` (covered in high-1).
+
+---
+
+## [info-3] Both tokens use consistent decimal handling
+
+**Severity**: Info  
+**Category**: evm-audit-precision-math  
+**Location**: Entire contract
+
+**Description**: The contract exclusively escrows and pays out CLAWD tokens (18 decimals). USDC (6 decimals) is only handled transiently during the swap in `postJobWithUsdc()` and is never mixed with CLAWD in arithmetic. The `paymentUsdcApprox` field is purely informational and not used in any calculations. No decimal mismatch vulnerabilities exist.
+
+---
+
+## Checklist Walkthrough
+
+Below is a systematic review of each checklist item:
+
+| # | Checklist Item | Status | Notes |
+|---|---------------|--------|-------|
+| 1 | Division before multiplication | ✅ PASS | Fee calc: `(amount * bps) / 10_000` — correct order |
+| 2 | Hidden div-before-mul in library calls | ✅ PASS | No `wmul`/`wdiv` or chained math library calls |
+| 3 | Extra divisions by scaling factor | ✅ PASS | Single division by 10_000, no double-scaling |
+| 4 | Division resulting in zero for small values | ✅ PASS | Minimum payment is 1e18 CLAWD; `1e18 * 500 / 10_000 = 5e16` — never zero |
+| 5 | Protocol-favoring rounding rule | ⚠️ MEDIUM-3 | Fee rounds down, should round up |
+| 6 | Inconsistent rounding across functions | ⚠️ HIGH-1, MEDIUM-1 | Fee recalculated independently in complete/claim/dispute |
+| 7 | Inverse fee calculation error | ✅ PASS | Fee is simple percentage, no inverse calc needed |
+| 8 | Overflow in unchecked blocks | ✅ PASS | No unchecked blocks |
+| 9 | Downcast overflow | ✅ PASS | No downcasts |
+| 10 | Negative-to-unsigned cast | ✅ PASS | No signed integers |
+| 11 | Signed-unsigned arithmetic | ✅ PASS | No signed integers |
+| 12 | Overflow in time-based calculations | ✅ PASS | `job.completedAt + DISPUTE_WINDOW` — safe with uint256 |
+| 13 | Oracle decimal mismatch | ✅ N/A | No oracles used |
+| 14 | Token decimal mismatch in price calculations | ✅ PASS | USDC only used in swap, not mixed with CLAWD arithmetic |
+| 15 | Decimal scaling for vault with non-18 assets | ✅ N/A | Not a vault |
+| 16 | Zero/one remaining after division | ✅ PASS | Fee remainder ≤ 1 wei, negligible |
+| 17 | Compounding when claiming simple interest | ✅ N/A | No interest/reward accrual |
+| 18 | Reward per token precision loss | ✅ N/A | No staking rewards |
+| 19 | Missing state update before reward claim | ✅ N/A | No reward mechanism |
+| 20 | Fee shares minted after reward distribution | ✅ N/A | No shares/minting |
+| 21 | Division by zero in assembly | ✅ PASS | No assembly |
+| 22 | `type(uint256).max` as sentinel value | ✅ PASS | Not used |
+| 23 | Extreme weight ratios cause overflow | ✅ N/A | No weighted pool math |
+| 24 | Solidity time literals are uint24 | ✅ PASS | `7 days` used as `uint256 constant`, no overflow risk |
+| 25 | Rounding direction must favor protocol | ⚠️ MEDIUM-3 | See finding |
+| 26 | Off-by-one in comparison operators | ✅ PASS | `block.timestamp > completedAt + DISPUTE_WINDOW` and `<= completedAt + DISPUTE_WINDOW` — consistent boundary (exactly at boundary = still in window) |
+| 27 | Assigning negative to uint reverts | ✅ PASS | No such patterns; underflow in `accumulatedFees` covered in HIGH-1 |
+| 28 | Unchecked blocks need explicit validation | ✅ PASS | No unchecked blocks |
+| 29 | Precision loss compounds across operations | ✅ PASS | Only single-step fee calculation, no chained divisions |
+| 30 | Division before mul hidden by function calls | ✅ PASS | No chained library math |
+| 31 | Rounding down to zero allows state changes | ✅ PASS | Min 1e18 CLAWD prevents zero-fee jobs (except USDC path — see LOW-1) |
+| 32 | ~50% value understatement from mixing precisions | ✅ PASS | No mixed-precision addition |
+| 33 | Excessive precision scaling — double-scaling | ✅ PASS | No scaling operations |
+| 34 | Mismatched precision — decimals vs hardcoded 1e18 | ✅ PASS | No cross-module precision flows |
+| 35 | Downcast overflow invalidates pre-downcast checks | ✅ PASS | No downcasts |
+| 36 | Rounding direction leaks value from protocol | ⚠️ MEDIUM-3 | Fee rounds down |
+
+---
+
+## Conclusion
+
+The contract is relatively simple in its math — a straightforward fee-on-payment escrow. The most significant finding is **HIGH-1**: the fee is recalculated independently at completion, claim, and dispute resolution using the *current* `protocolFeeBps`, which means any fee rate change between these events causes accounting mismatches that can permanently lock funds via underflow revert. The recommended fix is to store the calculated fee in the Job struct at completion time and reuse that stored value everywhere.
+
+The remaining findings are medium/low severity — rounding direction (protocol loses dust per job), the `withdrawStuckTokens` foot-gun, and missing minimum payment validation on the USDC swap path.


### PR DESCRIPTION
## Summary
- Updates `LEFTCLAW_SERVICES_SKILL.md` to reflect V2 contract (`0xb2fb486a9569ad2c97d9c73936b46ef7fdaa413a`)
- Adds explicit warning that `consult` and `consult-deep` are **browser-only** — no x402 API endpoint exists for them
- Updates service type IDs/prices to match V2 deploy (test mode)
- Updates job lifecycle to reflect V2 (no dispute window, immediate payment on accept, no fee)
- Documents all payment methods (CLAWD, USDC, ETH, CV, x402)

## Why
The bot was attempting to call `/api/consult` via x402 which returns a 404. Consultation sessions happen in the browser at leftclaw.services after posting a job on-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)