### PR TITLE
fix(security): redact consult prompts and gate session/messages endpoints

### DIFF
--- a/packages/nextjs/app/api/job/[id]/chat/route.ts
+++ b/packages/nextjs/app/api/job/[id]/chat/route.ts
@@ -11,6 +11,7 @@ import { execSync } from "child_process";
 import Anthropic from "@anthropic-ai/sdk";
 import deployedContracts from "~~/contracts/deployedContracts";
 import { getMessages, addJobMessage } from "~~/lib/jobMessages";
+import { getConsultPrompt } from "~~/lib/consultPrompt";
 
 const { address, abi } = deployedContracts[8453].LeftClawServicesV2;
 
@@ -304,6 +305,13 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     return Response.json({ error: "Rate limit exceeded (3/hour for active jobs)", messagesUsed: rl.used, messagesRemaining: 0 }, { status: 429 });
   }
 
+  // For consult jobs, the on-chain description is a placeholder; the real prompt
+  // lives off-chain in KV (consultPrompt store). Old consult jobs have the real
+  // prompt on-chain — fall back to that.
+  const isConsultJob = CONSULTATION_TYPE_IDS.includes(jobServiceTypeId);
+  const offChainPrompt = isConsultJob ? await getConsultPrompt(jobId) : null;
+  const descriptionForContext = offChainPrompt || job.description || "";
+
   // Fetch context
   const numericId = jobId.startsWith("cv-") ? BigInt(jobId.slice(3)) : BigInt(jobId);
   const [workLogsRaw, messages, planMd, userJourneyMd, descriptionContent, skillMd] = await Promise.all([
@@ -311,7 +319,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     getMessages(jobId),
     fetchGitHubFile(jobId, "PLAN.md"),
     fetchGitHubFile(jobId, "USERJOURNEY.md"),
-    fetchDescriptionContent(job.description || ""),
+    fetchDescriptionContent(descriptionForContext),
     fetchSkillMd(jobId),
   ]);
 

--- a/packages/nextjs/app/api/job/[id]/messages/route.ts
+++ b/packages/nextjs/app/api/job/[id]/messages/route.ts
@@ -3,7 +3,6 @@ import { createPublicClient, http } from "viem";
 import { base } from "viem/chains";
 import { getMessages, addJobMessage } from "~~/lib/jobMessages";
 import { verifyAuthSignature } from "~~/lib/authSignature";
-import { getRegisteredWorkers } from "~~/lib/workerAuth";
 import deployedContracts from "~~/contracts/deployedContracts";
 
 const { address: contractAddress, abi } = deployedContracts[8453].LeftClawServicesV2;
@@ -37,7 +36,9 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     return new Response(JSON.stringify({ error: "Invalid signature" }), { status: 401 });
   }
 
-  // Resolve job owner from chain; allow the assigned worker and registered workers too
+  // Only the job owner (client) or the assigned worker may read job messages.
+  // Previously this also allowed any registered worker, which let any builder
+  // who'd been added as a worker enumerate other clients' job messages.
   let jobClient: string | null = null;
   let jobWorker: string | null = null;
   try {
@@ -51,16 +52,13 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     jobClient = job.client.toLowerCase();
     jobWorker = job.worker.toLowerCase();
   } catch {
-    // jobId not found on chain — fall through to worker check
+    return new Response(JSON.stringify({ error: "Job not found" }), { status: 404 });
   }
 
   const caller = callerAddress.toLowerCase();
-  const isOwnerOrWorker = caller === jobClient || caller === jobWorker;
-  if (!isOwnerOrWorker) {
-    const workers = await getRegisteredWorkers();
-    if (!workers.includes(caller)) {
-      return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
-    }
+  const isOwnerOrAssignedWorker = caller === jobClient || (jobWorker && caller === jobWorker);
+  if (!isOwnerOrAssignedWorker) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
   }
 
   const messages = await getMessages(jobId);

--- a/packages/nextjs/app/api/session/[sessionId]/route.ts
+++ b/packages/nextjs/app/api/session/[sessionId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession, updateSession } from "~~/lib/sessionStore";
+import { verifyAuthSignature } from "~~/lib/authSignature";
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ sessionId: string }> }) {
   const { sessionId } = await params;
@@ -9,15 +10,31 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ sess
     return NextResponse.json({ error: "Session not found or expired" }, { status: 404 });
   }
 
+  // Verify caller owns the session before returning the prompt or chat history.
+  // Auth is the long-lived "LeftClaw Services Auth" signature (same pattern as
+  // /api/job/[id]/messages). Sessions without a payerAddress (legacy) cannot be
+  // verified, so sensitive fields stay redacted.
+  const callerAddress = req.nextUrl.searchParams.get("address");
+  const sig = req.nextUrl.searchParams.get("sig");
+
+  let authed = false;
+  if (callerAddress && sig && session.payerAddress) {
+    const sigValid = await verifyAuthSignature(callerAddress, sig);
+    if (sigValid && callerAddress.toLowerCase() === session.payerAddress.toLowerCase()) {
+      authed = true;
+    }
+  }
+
   return NextResponse.json({
     id: session.id,
     serviceType: session.serviceType,
-    description: session.description,
     status: session.status,
     maxMessages: session.maxMessages,
     planGenerations: session.planGenerations || 0,
     expiresAt: session.expiresAt,
-    messages: session.messages,
+    authed,
+    description: authed ? session.description : null,
+    messages: authed ? session.messages : [],
   });
 }
 

--- a/packages/nextjs/app/chat/x402/[sessionId]/X402ChatClient.tsx
+++ b/packages/nextjs/app/chat/x402/[sessionId]/X402ChatClient.tsx
@@ -3,6 +3,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { useParams, useRouter } from "next/navigation";
+import { useAccount, useSignMessage } from "wagmi";
+import { AUTH_SIGN_MESSAGE } from "~~/lib/authSignature";
+import { getCachedAuthSignature, setCachedAuthSignature } from "~~/utils/authSignatureCache";
 
 interface Message {
   role: "user" | "assistant";
@@ -12,12 +15,13 @@ interface Message {
 interface SessionInfo {
   id: string;
   serviceType: string;
-  description: string;
+  description: string | null;
   status: string;
   maxMessages: number;
   planGenerations: number;
   expiresAt: string;
   messages: Message[];
+  authed: boolean;
 }
 
 const SERVICE_LABELS: Record<string, string> = {
@@ -33,6 +37,8 @@ export default function X402ChatClient() {
   const params = useParams();
   const router = useRouter();
   const sessionId = params.sessionId as string;
+  const { address } = useAccount();
+  const { signMessageAsync } = useSignMessage();
 
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [loading, setLoading] = useState(true);
@@ -46,16 +52,22 @@ export default function X402ChatClient() {
   const [planDescription, setPlanDescription] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [routeSuggestion, setRouteSuggestion] = useState<{ type: "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA"; summary: string } | null>(null);
+  const [sigPending, setSigPending] = useState(false);
+  const [sigError, setSigError] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const autoSentRef = useRef(false);
   const MAX_CHARS = 1000;
 
-  // Load session info
+  // Load session info — requires owner signature to unlock description + history
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(`/api/session/${sessionId}`);
+        const cached = address ? getCachedAuthSignature(address) : null;
+        const qs = address && cached
+          ? `?address=${encodeURIComponent(address)}&sig=${encodeURIComponent(cached)}`
+          : "";
+        const res = await fetch(`/api/session/${sessionId}${qs}`);
         if (!res.ok) {
           setError(res.status === 404 ? "Session not found or expired" : "Failed to load session");
           return;
@@ -71,7 +83,38 @@ export default function X402ChatClient() {
       }
     }
     load();
-  }, [sessionId]);
+  }, [sessionId, address]);
+
+  const handleUnlock = async () => {
+    if (!address) return;
+    setSigError(null);
+    setSigPending(true);
+    try {
+      let sig = getCachedAuthSignature(address);
+      if (!sig) {
+        sig = await signMessageAsync({ message: AUTH_SIGN_MESSAGE });
+        setCachedAuthSignature(address, sig);
+      }
+      const res = await fetch(
+        `/api/session/${sessionId}?address=${encodeURIComponent(address)}&sig=${encodeURIComponent(sig)}`,
+      );
+      if (!res.ok) {
+        setSigError("Failed to load session");
+        return;
+      }
+      const data: SessionInfo = await res.json();
+      setSession(data);
+      setMessages(data.messages || []);
+      setPlanGenerations(data.planGenerations || 0);
+      if (!data.authed) {
+        setSigError("This wallet is not the session owner.");
+      }
+    } catch {
+      setSigError("Signature required to view this session.");
+    } finally {
+      setSigPending(false);
+    }
+  };
 
   // Scroll on new messages
   useEffect(() => {
@@ -230,9 +273,11 @@ export default function X402ChatClient() {
   const isConsultation = session?.serviceType === "CONSULT_QUICK" || session?.serviceType === "CONSULT_DEEP";
   const showPlanButton = isConsultation && messages.length >= 4 && !isStreaming && planGenerations < MAX_PLAN_GENERATIONS && !planGistUrl;
 
-  // Auto-start conversation
+  // Auto-start conversation — only after the session is unlocked, otherwise we'd
+  // greet without the user's actual prompt and lose the opening context.
   useEffect(() => {
     if (!session || loading || messages.length > 0 || autoSentRef.current) return;
+    if (!session.authed) return;
     autoSentRef.current = true;
 
     if (session.description) {
@@ -262,6 +307,26 @@ export default function X402ChatClient() {
   }
 
   if (!session) return null;
+
+  if (!session.authed) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 px-4">
+        <div className="text-5xl mb-4">🔒</div>
+        <p className="text-xl font-bold mb-2">Session content is private</p>
+        <p className="opacity-70 text-sm text-center max-w-md mb-6">
+          Sign with the wallet that paid for this session to view your prompt and chat history.
+        </p>
+        {address ? (
+          <button className="btn btn-primary" onClick={handleUnlock} disabled={sigPending}>
+            {sigPending ? "Signing..." : "Unlock with wallet"}
+          </button>
+        ) : (
+          <p className="opacity-60 text-sm">Connect the wallet that paid for this session.</p>
+        )}
+        {sigError && <p className="mt-4 text-sm text-error">{sigError}</p>}
+      </div>
+    );
+  }
 
   const isExpired = new Date(session.expiresAt) < new Date();
   const userMsgCount = messages.filter(m => m.role === "user").length;

--- a/packages/nextjs/app/jobs/[id]/JobDetailClient.tsx
+++ b/packages/nextjs/app/jobs/[id]/JobDetailClient.tsx
@@ -276,12 +276,21 @@ export default function JobDetailClient() {
               )}
             </div>
 
-            {job.description && (
+            {job.description && (!isConsult || isClient) && (
               <>
                 <div className="divider"></div>
                 <div>
                   <span className="text-sm opacity-50">Description</span>
                   <p className="mt-1 whitespace-pre-wrap">{job.description}</p>
+                </div>
+              </>
+            )}
+            {isConsult && !isClient && (
+              <>
+                <div className="divider"></div>
+                <div>
+                  <span className="text-sm opacity-50">Description</span>
+                  <p className="mt-1 italic opacity-60">Consultation prompt is private to the client.</p>
                 </div>
               </>
             )}

--- a/packages/nextjs/app/jobs/x402/[sessionId]/X402JobClient.tsx
+++ b/packages/nextjs/app/jobs/x402/[sessionId]/X402JobClient.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import ReactMarkdown from "react-markdown";
+import { useAccount, useSignMessage } from "wagmi";
+import { AUTH_SIGN_MESSAGE } from "~~/lib/authSignature";
+import { getCachedAuthSignature, setCachedAuthSignature } from "~~/utils/authSignatureCache";
 
 interface Message {
   role: "user" | "assistant";
@@ -13,12 +16,13 @@ interface Message {
 interface SessionInfo {
   id: string;
   serviceType: string;
-  description: string;
+  description: string | null;
   status: string;
   maxMessages: number;
   planGenerations: number;
   expiresAt: string;
   messages: Message[];
+  authed: boolean;
 }
 
 const SERVICE_LABELS: Record<string, { name: string; icon: string }> = {
@@ -40,51 +44,78 @@ const STATUS_CONFIG: Record<string, { label: string; badge: string; desc: string
 export default function X402JobClient() {
   const params = useParams();
   const sessionId = params.sessionId as string;
+  const { address } = useAccount();
+  const { signMessageAsync } = useSignMessage();
 
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showAllMessages, setShowAllMessages] = useState(false);
+  const [sigPending, setSigPending] = useState(false);
+  const [sigError, setSigError] = useState<string | null>(null);
 
-  // Poll for updates
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch(`/api/session/${sessionId}`);
-        if (!res.ok) {
-          setError(res.status === 404 ? "Session not found or expired" : "Failed to load session");
-          return;
-        }
-        const data: SessionInfo = await res.json();
-        setSession(data);
-      } catch {
-        setError("Failed to load session");
-      } finally {
-        setLoading(false);
-      }
+  const fetchSession = async (sig?: string): Promise<SessionInfo | null> => {
+    const qs = address && sig ? `?address=${encodeURIComponent(address)}&sig=${encodeURIComponent(sig)}` : "";
+    const res = await fetch(`/api/session/${sessionId}${qs}`);
+    if (!res.ok) {
+      setError(res.status === 404 ? "Session not found or expired" : "Failed to load session");
+      return null;
     }
+    return (await res.json()) as SessionInfo;
+  };
 
+  // Initial load — try with cached sig if available, else fetch unauthed.
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const cached = address ? getCachedAuthSignature(address) : null;
+      const data = await fetchSession(cached || undefined);
+      if (cancelled) return;
+      if (data) setSession(data);
+      setLoading(false);
+    }
     load();
 
-    // Auto-refresh every 10s while active
     const interval = setInterval(async () => {
-      try {
-        const res = await fetch(`/api/session/${sessionId}`);
-        if (res.ok) {
-          const data: SessionInfo = await res.json();
-          setSession(data);
-          // Stop polling if completed or expired
-          if (data.status !== "active") {
-            clearInterval(interval);
-          }
-        }
-      } catch {
-        /* ignore poll errors */
+      const cached = address ? getCachedAuthSignature(address) : null;
+      const data = await fetchSession(cached || undefined);
+      if (cancelled) return;
+      if (data) {
+        setSession(data);
+        if (data.status !== "active") clearInterval(interval);
       }
     }, 10000);
 
-    return () => clearInterval(interval);
-  }, [sessionId]);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId, address]);
+
+  const handleUnlock = async () => {
+    if (!address) return;
+    setSigError(null);
+    setSigPending(true);
+    try {
+      let sig = getCachedAuthSignature(address);
+      if (!sig) {
+        sig = await signMessageAsync({ message: AUTH_SIGN_MESSAGE });
+        setCachedAuthSignature(address, sig);
+      }
+      const data = await fetchSession(sig);
+      if (data) {
+        setSession(data);
+        if (!data.authed) {
+          setSigError("This wallet is not the session owner.");
+        }
+      }
+    } catch {
+      setSigError("Signature required to view this session.");
+    } finally {
+      setSigPending(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -177,16 +208,32 @@ export default function X402JobClient() {
               </div>
             </div>
 
-            {/* Description */}
-            {session.description && (
-              <>
-                <div className="divider" />
-                <div>
-                  <span className="text-sm opacity-50">Request</span>
-                  <p className="mt-1 whitespace-pre-wrap">{session.description}</p>
+            {/* Description — gated behind owner signature */}
+            <div className="divider" />
+            <div>
+              <span className="text-sm opacity-50">Request</span>
+              {session.authed && session.description ? (
+                <p className="mt-1 whitespace-pre-wrap">{session.description}</p>
+              ) : (
+                <div className="mt-1">
+                  <p className="italic opacity-60 text-sm">
+                    🔒 Session content is private. Sign with the paying wallet to view your request and chat history.
+                  </p>
+                  {address ? (
+                    <button
+                      className="btn btn-sm btn-outline mt-2"
+                      onClick={handleUnlock}
+                      disabled={sigPending}
+                    >
+                      {sigPending ? "Signing..." : "Unlock with wallet"}
+                    </button>
+                  ) : (
+                    <p className="mt-2 text-sm opacity-60">Connect the wallet that paid for this session.</p>
+                  )}
+                  {sigError && <p className="mt-2 text-sm text-error">{sigError}</p>}
                 </div>
-              </>
-            )}
+              )}
+            </div>
 
             {/* Final deliverable — shown prominently when complete */}
             {(isComplete || atLimit) && finalMessage && (

--- a/packages/nextjs/lib/consultPrompt.ts
+++ b/packages/nextjs/lib/consultPrompt.ts
@@ -1,0 +1,47 @@
+import { getKV } from "./kv";
+import deployedContracts from "~~/contracts/deployedContracts";
+
+const CONTRACT_ADDR = deployedContracts[8453]?.LeftClawServicesV2?.address || "default";
+const TTL_SECONDS = 365 * 24 * 60 * 60;
+
+export const ON_CHAIN_PLACEHOLDER = "Consult — prompt stored off-chain (private)";
+
+export interface ConsultPrompt {
+  description: string;
+  storedAt: string;
+}
+
+const memStore = new Map<string, ConsultPrompt>();
+
+function key(jobId: string | number): string {
+  return `consultPrompt:${CONTRACT_ADDR}:${jobId}`;
+}
+
+export async function saveConsultPrompt(jobId: string | number, description: string): Promise<void> {
+  const payload: ConsultPrompt = {
+    description,
+    storedAt: new Date().toISOString(),
+  };
+  const kv = getKV();
+  if (kv) {
+    await kv.set(key(jobId), JSON.stringify(payload), { ex: TTL_SECONDS });
+  } else {
+    memStore.set(String(jobId), payload);
+  }
+}
+
+export async function getConsultPrompt(jobId: string | number): Promise<string | null> {
+  const kv = getKV();
+  if (kv) {
+    const data = await kv.get<string>(key(jobId));
+    if (!data) return null;
+    try {
+      const parsed: ConsultPrompt = typeof data === "string" ? JSON.parse(data) : data;
+      return parsed.description || null;
+    } catch {
+      return null;
+    }
+  }
+  const cached = memStore.get(String(jobId));
+  return cached?.description || null;
+}

--- a/packages/nextjs/lib/postJobFor.ts
+++ b/packages/nextjs/lib/postJobFor.ts
@@ -2,9 +2,14 @@ import { createPublicClient, createWalletClient, http, parseAbi } from "viem";
 import { base } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 import deployedContracts from "~~/contracts/deployedContracts";
+import { ON_CHAIN_PLACEHOLDER, saveConsultPrompt } from "./consultPrompt";
 
 const CONTRACT_ADDRESS = deployedContracts[8453]?.LeftClawServicesV2?.address as `0x${string}`;
 const USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as const;
+
+// Service types whose description is the user's private prompt to the LLM.
+// For these, we store the real prompt off-chain and post a placeholder on-chain.
+const PRIVATE_PROMPT_SERVICE_TYPES = new Set([1, 2]); // Quick + Deep Consultation
 
 const CONTRACT_ABI = parseAbi([
   "function postJobFor(address client, uint256 serviceTypeId, string description, uint256 minClawdOut) external",
@@ -73,18 +78,28 @@ export async function postJobForOnChain(
     functionName: "nextJobId",
   });
 
+  const jobId = Number(nextId);
+  const isPrivatePrompt = PRIVATE_PROMPT_SERVICE_TYPES.has(serviceTypeId);
+
+  // For consult jobs, persist the real prompt off-chain BEFORE posting on-chain
+  // so the chat handler can resolve it as soon as the tx confirms. The on-chain
+  // description gets a placeholder so the public contract state never sees the prompt.
+  if (isPrivatePrompt) {
+    await saveConsultPrompt(jobId, description);
+  }
+
+  const onChainDescription = isPrivatePrompt ? ON_CHAIN_PLACEHOLDER : description;
+
   const hash = await walletClient.writeContract({
     address: CONTRACT_ADDRESS,
     abi: CONTRACT_ABI,
     functionName: "postJobFor",
-    args: [account.address, BigInt(serviceTypeId), description, 0n],
+    args: [account.address, BigInt(serviceTypeId), onChainDescription, 0n],
     chain: base,
     account: account,
   });
 
   await publicClient.waitForTransactionReceipt({ hash, retryCount: 20, retryDelay: 3_000 });
-
-  const jobId = Number(nextId);
 
   // Fire sanitize (fire-and-forget) — runs Claude check, writes result to KV.
   // Must be awaited enough to kick off but not block the response; use dynamic import


### PR DESCRIPTION
## Summary

- Consult job descriptions (svc 1, 2) were being posted on-chain via `postJobFor`, exposing every Quick/Deep Consult prompt to anyone with RPC access (`getJob(n)`). Now the prompt is stored off-chain in Upstash KV (`lib/consultPrompt.ts`) and only a placeholder string hits the chain.
- `/api/session/[sessionId]` was unauthenticated and returned `description` + full chat `messages` to anyone with the sessionId. Now it redacts both unless the caller signs with the wallet that paid for the session.
- `/api/job/[id]/messages` allowed *any* registered worker to read any job's messages. Now strictly the job client or the assigned worker.
- `/jobs/[id]` page used to render the description to anyone for consult jobs. Now gated on `(!isConsult || isClient)`.
- X402 job/chat UI wired up to the existing `LeftClaw Services Auth` wallet sig pattern (cached 7 days). Chat auto-start waits for unlock so the opening prompt isn't lost.

Reported by Zeitgeist Jones via $CLAWD chat.

## Caveats

- **Past consults already on-chain remain public** — this stops new ones from leaking and gates the API/UI surface. Affected past clients should be notified separately (enumerate `getJob(0..nextJobId)` filtered to `serviceTypeId ∈ {1,2}`).
- **`/api/job/summaries`** (LLM-generated tldr summaries) is still unauthenticated. Lower-severity but same class — separate patch.
- **Two-step deploy was an option but skipped** per the user's call. Full change ships in one go.

## Test plan

- [ ] Post a new Quick Consult; confirm `getJob(N).description` on Basescan shows the placeholder string, not the user's prompt
- [ ] Confirm the consult chat still works end-to-end (chat handler reads off-chain prompt + responds)
- [ ] Old consult jobs (description on-chain) still chat correctly via the on-chain fallback path
- [ ] `GET /api/session/{id}` without sig returns `{description: null, messages: [], authed: false}`
- [ ] `GET /api/session/{id}?address=…&sig=…` with payer's `LeftClaw Services Auth` sig returns full data with `authed: true`
- [ ] `GET /api/session/{id}?address=…&sig=…` with non-payer wallet returns `authed: false` and redacted fields
- [ ] X402 chat page shows the unlock screen until owner signs, then auto-starts the conversation
- [ ] `/api/job/{id}/messages` rejects a registered worker who isn't assigned to that job (was previously allowed)
- [ ] `/jobs/{id}` page does not render `description` for a consult job when viewed by a non-client wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)