### PR TITLE
fix(chat): bump /api/chat maxDuration to 300s for web_search tool use

### DIFF
--- a/packages/nextjs/vercel.json
+++ b/packages/nextjs/vercel.json
@@ -4,7 +4,8 @@
     "app/api/pfp/generate-payment/route.ts": { "maxDuration": 300 },
     "app/api/pfp/generate/route.ts": { "maxDuration": 60 },
     "app/api/pfp/generate-cv/route.ts": { "maxDuration": 60 },
-    "app/api/job/pfp-sweep/route.ts": { "maxDuration": 300 }
+    "app/api/job/pfp-sweep/route.ts": { "maxDuration": 300 },
+    "app/api/chat/route.ts": { "maxDuration": 300 }
   },
   "crons": [
     { "path": "/api/job/pfp-sweep", "schedule": "0 */3 * * *" },


### PR DESCRIPTION
## Summary

`/api/chat/route.ts` was hitting Vercel's default function timeout (10s hobby / 60s pro) when Anthropic's `web_search` tool fired. The bot's "Perfect, let me verify..." prelude streamed fine, then the function got cut off before the search result + post-search generation could complete — leaving the user with an empty response.

`web_search` can take 10–30s per call. `chat/route.ts:469` allows `max_uses: 5`. Plus text generation around it. 300s matches the longest existing override (`app/api/pfp/generate-payment`, `app/api/job/pfp-sweep`).

## Test plan

- [ ] Open a consultation chat and ask something that triggers a web search (e.g. "what's the latest pricing for X service?")
- [ ] Verify the bot doesn't hang mid-stream — search prelude appears, then full answer streams in
- [ ] Spot-check non-search chats still work (no regression for plain LLM responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)