### PR TITLE
fix(chat): remove web_search tool — Bankr proxy doesn't support it

### DIFF
--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -462,11 +462,10 @@ export async function POST(req: NextRequest) {
       max_tokens: 4096,
       system: systemPrompt,
       stream: true,
-      // Anthropic server-side web_search tool. Lets the bot look up current
-      // third-party pricing/quotas/docs instead of confabulating from training data.
-      // Caveat: Bankr's org must have web search enabled — if not, requests fail
-      // and we'll need to remove this. ~$0.01/search, capped at 5 per turn.
-      tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 5 }],
+      // web_search tool was removed: Bankr proxy doesn't support
+      // Anthropic's server-side web_search_20250305 tool. The model would emit
+      // a tool_use block, the proxy couldn't fulfill it, and the stream produced
+      // no further text — leaving users with empty bot responses mid-conversation.
       messages: isGreeting
         ? [{ role: "user", content: "Hello" }]
         : messages.map((m: { role: string; content: string }) => ({


### PR DESCRIPTION
## Summary

Reverts the \`web_search_20250305\` tool registration added in 971478e. Bankr's proxy (\`llm.bankr.bot\`) doesn't support Anthropic's server-side web_search tool — instead of failing the request with 4xx (which the original commit anticipated), it returns a 200 stream that emits the tool_use block and then produces no further text content.

User-visible symptom: bot says something like "Perfect, let me verify…" and then renders an empty bubble. Subsequent messages also fail because the model wants to keep using the tool. Reproduced live during a CV consult session.

The previous bump of \`/api/chat\` \`maxDuration\` to 300s in #42 was orthogonal — bot wasn't timing out, the stream was just ending early.

## Test plan

- [ ] Ask the consult bot a question that previously triggered a search (e.g. "what's the latest Uniswap V2 deployment on Base?")
- [ ] Verify response streams normally (model answers from training, may suggest checking docs)
- [ ] Spot-check non-search consults still work
- [ ] No empty bot bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)