### PR TITLE
chore(model): upgrade consultation + sanitize to Claude Opus 4.7

### DIFF
--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -458,7 +458,7 @@ export async function POST(req: NextRequest) {
       "X-API-Key": apiKey,
     },
     body: JSON.stringify({
-      model: "claude-opus-4.6",
+      model: "claude-opus-4.7",
       max_tokens: 4096,
       system: systemPrompt,
       stream: true,

--- a/packages/nextjs/app/api/job/[id]/chat/route.ts
+++ b/packages/nextjs/app/api/job/[id]/chat/route.ts
@@ -484,7 +484,7 @@ You can use your tools to read additional repo files, answer escalations, or req
 
   for (let i = 0; i < maxIterations; i++) {
     const response = await anthropic.messages.create({
-      model: "claude-sonnet-4.6",
+      model: "claude-opus-4.7",
       max_tokens: 2000,
       system: systemPrompt,
       tools,

--- a/packages/nextjs/lib/sanitize.ts
+++ b/packages/nextjs/lib/sanitize.ts
@@ -92,7 +92,7 @@ async function _doCheck(jobId: string, text: string): Promise<SanitizationResult
         "anthropic-version": "2023-06-01",
       },
       body: JSON.stringify({
-        model: "claude-sonnet-4-20250514",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         temperature: 0,
         system: SANITIZE_PROMPT,


### PR DESCRIPTION
## Summary

Bumps three Claude model references to Opus 4.7:

| File | Provider | Old → New |
|---|---|---|
| \`app/api/chat/route.ts\` | Bankr proxy | \`claude-opus-4.6\` → \`claude-opus-4.7\` |
| \`app/api/job/[id]/chat/route.ts\` | Bankr proxy | \`claude-sonnet-4.6\` → \`claude-opus-4.7\` |
| \`lib/sanitize.ts\` | Direct Anthropic API | \`claude-sonnet-4-20250514\` → \`claude-opus-4-7\` |

Note: Bankr uses dot notation (\`claude-opus-4.7\`); direct Anthropic uses dash notation per their official model IDs (\`claude-opus-4-7\`).

## Heads up

\`lib/sanitize.ts\` runs on every job posting (prompt-injection check). Opus 4.7 is more accurate but slower + pricier than Sonnet. Watch for latency regressions at the post-job boundary; if it hurts UX we can downgrade just that one to Sonnet 4.6.

## Test plan

- [ ] Open a consultation chat (\`/chat/cv-...\`) and confirm streaming responses look healthy and on-model
- [ ] Open an on-chain job chat and confirm same
- [ ] Post a new job and confirm sanitization completes (\`/api/job/sanitize?jobId=...\` returns \`safe: true\`) without a noticeable hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)