### PR TITLE
fix(sanitize): drop back to Sonnet 4.6 — Opus 4.7 too slow for gating check

### DIFF
--- a/packages/nextjs/lib/sanitize.ts
+++ b/packages/nextjs/lib/sanitize.ts
@@ -92,7 +92,7 @@ async function _doCheck(jobId: string, text: string): Promise<SanitizationResult
         "anthropic-version": "2023-06-01",
       },
       body: JSON.stringify({
-        model: "claude-opus-4-7",
+        model: "claude-sonnet-4-6",
         max_tokens: 256,
         temperature: 0,
         system: SANITIZE_PROMPT,


### PR DESCRIPTION
## Summary

Sanitize runs on every job posting and gates the post-flow UX — the \`/chat/[jobId]\` page polls \`GET /api/job/sanitize?jobId=N\` until the result lands. Opus 4.7 (shipped in #44) was taking long enough to hit Vercel's default function timeout, leaving users stuck on "Reviewing your request..." indefinitely.

This PR reverts just the sanitize model to Sonnet 4.6. User-facing chat (\`/api/chat\`, \`/api/job/[id]/chat\`) stays on Opus 4.7 — that's where reasoning quality matters. Sanitize is a binary classifier + one-line tldr; Sonnet is plenty.

Bankr proxy isn't used here (sanitize calls Anthropic directly), so this uses dash notation per Anthropic's official model ID.

## Test plan

- [ ] Post a new job (any service type)
- [ ] Confirm \`/api/job/sanitize?jobId=N\` returns \`{safe: true, ...}\` within ~2s
- [ ] \`/chat/[jobId]\` page proceeds past "Reviewing your request..." and loads the chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)