### PR TITLE
feat(jobs): owner can read their own consult prompt on /jobs/[id]

### DIFF
--- a/packages/nextjs/app/api/job/[id]/consult-prompt/route.ts
+++ b/packages/nextjs/app/api/job/[id]/consult-prompt/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createPublicClient, http } from "viem";
+import { base } from "viem/chains";
+import { getConsultPrompt } from "~~/lib/consultPrompt";
+import { verifyAuthSignature } from "~~/lib/authSignature";
+import deployedContracts from "~~/contracts/deployedContracts";
+
+const { address: contractAddress, abi } = deployedContracts[8453].LeftClawServicesV2;
+
+const viemClient = createPublicClient({
+  chain: base,
+  transport: http(
+    process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
+      ? `https://base-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`
+      : undefined,
+  ),
+});
+
+const CONSULT_SERVICE_TYPE_IDS = new Set([1, 2]);
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id: jobId } = await params;
+  if (!jobId) return NextResponse.json({ error: "Job ID required" }, { status: 400 });
+
+  const callerAddress = req.nextUrl.searchParams.get("address");
+  const sig = req.nextUrl.searchParams.get("sig");
+
+  if (!callerAddress || !sig) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const sigValid = await verifyAuthSignature(callerAddress, sig);
+  if (!sigValid) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  let job: any;
+  try {
+    job = await viemClient.readContract({
+      address: contractAddress,
+      abi,
+      functionName: "getJob",
+      args: [BigInt(jobId)],
+    });
+  } catch {
+    return NextResponse.json({ error: "Job not found" }, { status: 404 });
+  }
+
+  if (job.client.toLowerCase() !== callerAddress.toLowerCase()) {
+    return NextResponse.json({ error: "Not the job client" }, { status: 403 });
+  }
+
+  if (!CONSULT_SERVICE_TYPE_IDS.has(Number(job.serviceTypeId))) {
+    return NextResponse.json({ error: "Not a consult job" }, { status: 400 });
+  }
+
+  const prompt = await getConsultPrompt(jobId);
+  return NextResponse.json({ jobId, description: prompt });
+}

--- a/packages/nextjs/app/jobs/[id]/JobDetailClient.tsx
+++ b/packages/nextjs/app/jobs/[id]/JobDetailClient.tsx
@@ -6,10 +6,12 @@ import JobChatPanel from "./JobChatPanel";
 import { useParams } from "next/navigation";
 import { Address } from "@scaffold-ui/components";
 import { formatUnits } from "viem";
-import { useAccount, usePublicClient, useReadContract, useWriteContract } from "wagmi";
+import { useAccount, usePublicClient, useReadContract, useSignMessage, useWriteContract } from "wagmi";
 import deployedContracts from "~~/contracts/deployedContracts";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 import { useCLAWDPrice } from "~~/hooks/scaffold-eth/useCLAWDPrice";
+import { AUTH_SIGN_MESSAGE } from "~~/lib/authSignature";
+import { getCachedAuthSignature, setCachedAuthSignature } from "~~/utils/authSignatureCache";
 
 function parseError(e: unknown): string {
   const msg = e instanceof Error ? e.message : String(e);
@@ -110,6 +112,49 @@ export default function JobDetailClient() {
       })
       .catch(() => triggerCheck());
   }, [jobId, job]);
+
+  // Consult prompt — for consult jobs, the on-chain description is just a placeholder.
+  // The owner can fetch the real prompt from KV by signing the auth message.
+  const [consultPrompt, setConsultPrompt] = useState<string | null>(null);
+  const [consultPromptError, setConsultPromptError] = useState<string | null>(null);
+  const { signMessageAsync } = useSignMessage();
+  useEffect(() => {
+    if (!jobId || !job || !address) return;
+    const serviceTypeId = Number(job.serviceTypeId);
+    const isOwnerAndConsult =
+      (serviceTypeId === 1 || serviceTypeId === 2) &&
+      address.toLowerCase() === job.client?.toLowerCase();
+    if (!isOwnerAndConsult) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        let sig = getCachedAuthSignature(address);
+        if (!sig) {
+          sig = await signMessageAsync({ message: AUTH_SIGN_MESSAGE });
+          setCachedAuthSignature(address, sig);
+        }
+        const res = await fetch(
+          `/api/job/${jobId}/consult-prompt?address=${encodeURIComponent(address)}&sig=${encodeURIComponent(sig)}`,
+        );
+        if (cancelled) return;
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          setConsultPromptError(err?.error || `Failed to load (${res.status})`);
+          return;
+        }
+        const data = await res.json();
+        setConsultPrompt(data.description || null);
+      } catch (e: any) {
+        if (cancelled) return;
+        setConsultPromptError(e?.message || "Failed to load prompt");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [jobId, job, address, signMessageAsync]);
 
   const clawdPrice = useCLAWDPrice();
   const { writeContractAsync } = useWriteContract();
@@ -276,12 +321,24 @@ export default function JobDetailClient() {
               )}
             </div>
 
-            {job.description && (!isConsult || isClient) && (
+            {(job.description || (isConsult && isClient)) && (!isConsult || isClient) && (
               <>
                 <div className="divider"></div>
                 <div>
                   <span className="text-sm opacity-50">Description</span>
-                  <p className="mt-1 whitespace-pre-wrap">{job.description}</p>
+                  {isConsult && isClient ? (
+                    consultPrompt !== null ? (
+                      <p className="mt-1 whitespace-pre-wrap">{consultPrompt}</p>
+                    ) : consultPromptError ? (
+                      <p className="mt-1 italic opacity-60 text-error">
+                        Couldn&apos;t load your prompt: {consultPromptError}
+                      </p>
+                    ) : (
+                      <p className="mt-1 italic opacity-60">🔒 Sign to unlock your consultation prompt…</p>
+                    )
+                  ) : (
+                    <p className="mt-1 whitespace-pre-wrap">{job.description}</p>
+                  )}
                 </div>
               </>
             )}


### PR DESCRIPTION
## Summary

After #41/#45 the on-chain description for consult jobs is just a placeholder string, so the JobDetail page rendered \`"Consult — prompt stored off-chain (private)"\` even to the *owner* viewing their own consult — not useful.

This PR lets the owner see their own prompt by fetching it from KV with a wallet signature.

## Changes

- New \`GET /api/job/[id]/consult-prompt\` — requires \`LeftClaw Services Auth\` signature, verifies caller is the on-chain \`job.client\` and the job is svc 1 or 2, returns the real prompt from KV (re-uses \`getConsultPrompt\` from #41).
- \`JobDetailClient\` — when the connected wallet matches \`job.client\` on a consult job, kicks off the fetch (uses cached auth sig, signs once if needed) and renders the real prompt where the placeholder used to show. Sign-pending state shows "🔒 Sign to unlock your consultation prompt…".

Non-clients continue to see "Consultation prompt is private to the client."

## Test plan

- [ ] Open \`/jobs/{N}\` for a consult you own with the right wallet → real prompt renders (after one signature, cached for 7 days)
- [ ] Open the same page disconnected or with a different wallet → see "private to the client"
- [ ] Open a build/audit job → behaves exactly as before (description from chain)
- [ ] \`GET /api/job/{N}/consult-prompt\` without sig → 401
- [ ] Same with valid sig from a non-client → 403
- [ ] Same on a non-consult job → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)