### PR TITLE
fix(sanitize): auto-recover stuck "Reviewing your request..." state

### DIFF
--- a/packages/nextjs/app/api/job/sanitize/route.ts
+++ b/packages/nextjs/app/api/job/sanitize/route.ts
@@ -1,16 +1,36 @@
 import { NextRequest } from "next/server";
+import { createPublicClient, http } from "viem";
+import { base } from "viem/chains";
 import { checkSanitization, getSanitization, setSanitization } from "~~/lib/sanitize";
+import { getConsultPrompt } from "~~/lib/consultPrompt";
+import deployedContracts from "~~/contracts/deployedContracts";
+
+const { address: contractAddress, abi } = deployedContracts[8453].LeftClawServicesV2;
+
+const viemClient = createPublicClient({
+  chain: base,
+  transport: http(
+    process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
+      ? `https://base-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`
+      : undefined,
+  ),
+});
 
 export async function POST(req: NextRequest) {
   try {
-    const { jobId, description, cvAutoPass } = await req.json();
+    const body = await req.json();
+    const { jobId, cvAutoPass } = body;
+    let description: string | undefined = body.description;
 
-    if (!jobId || !description) {
-      return Response.json({ error: "jobId and description required" }, { status: 400 });
+    if (!jobId) {
+      return Response.json({ error: "jobId required" }, { status: 400 });
     }
 
     // CV consults auto-pass sanitization — off-chain payment, no gate needed
     if (cvAutoPass && String(jobId).startsWith("cv-")) {
+      if (!description) {
+        return Response.json({ error: "description required for cvAutoPass" }, { status: 400 });
+      }
       const result = {
         jobId: String(jobId),
         safe: true,
@@ -21,27 +41,36 @@ export async function POST(req: NextRequest) {
       return Response.json({ ...result, onChain: false });
     }
 
-    // Note: job.sanitized doesn't exist on-chain yet — markSanitized is not in the deployed ABI.
-    // Skip on-chain flag check; rely on Redis/KV for sanitization state.
+    // If no description provided, look it up. Supports recovery from stuck
+    // "Reviewing your request..." states: clients can retrigger with just
+    // {jobId} and the server resolves the prompt itself.
+    if (!description) {
+      // Off-chain consult prompt store (svc 1, 2 posted via current flow)
+      const offChain = await getConsultPrompt(jobId);
+      if (offChain) {
+        description = offChain;
+      } else if (!String(jobId).startsWith("cv-")) {
+        // Fallback to on-chain (build/audit/etc and pre-PR-#41 consults)
+        try {
+          const job = (await viemClient.readContract({
+            address: contractAddress,
+            abi,
+            functionName: "getJob",
+            args: [BigInt(jobId)],
+          })) as any;
+          description = job.description || undefined;
+        } catch {}
+      }
+    }
 
-    // Run Opus analysis
+    if (!description) {
+      return Response.json(
+        { error: "description not provided and could not be resolved from KV or chain" },
+        { status: 400 },
+      );
+    }
+
     const result = await checkSanitization(String(jobId), description);
-
-    // Placeholder: markSanitized doesn't exist in deployed contract ABI yet.
-    // When added, uncomment to write on-chain flag.
-    // if (result.safe && process.env.SANITIZER_PRIVATE_KEY) {
-    //   try {
-    //     const account = privateKeyToAccount(process.env.SANITIZER_PRIVATE_KEY as `0x${string}`);
-    //     const wallet = createWalletClient({ account, chain: base, transport });
-    //     const hash = await wallet.writeContract({
-    //       address, abi, functionName: "markSanitized", args: [BigInt(jobId)],
-    //     });
-    //     return Response.json({ ...result, onChain: true, txHash: hash });
-    //   } catch (txErr: any) {
-    //     console.error("markSanitized tx failed:", txErr.message);
-    //   }
-    // }
-
     return Response.json({ ...result, onChain: false });
   } catch (e) {
     console.error("Sanitize route error:", e);

--- a/packages/nextjs/app/chat/[jobId]/ChatClient.tsx
+++ b/packages/nextjs/app/chat/[jobId]/ChatClient.tsx
@@ -131,17 +131,71 @@ export default function ChatPage() {
     if (!jobExists || sanitizeRef.current) return;
     sanitizeRef.current = true;
 
-    // Check sanitization status (triggered at job creation, not here)
-    fetch(`/api/job/sanitize?jobId=${jobId}`)
-      .then(res => {
-        if (res.ok) return res.json().then(d => { setSanitized(d.safe); if (!d.safe) setSanitizeError(d.reason); });
-        // Not yet sanitized — poll until it is (should be triggered by payment page)
-        setSanitized(false);
-        setSanitizeError("Job is pending security review. Please wait...");
-      })
-      .catch(() => { setSanitized(false); setSanitizeError("Failed to verify job safety"); });
+    // Poll the sanitize status. If still pending after a few seconds, fire a
+    // recovery POST — the server-side endpoint resolves the description from
+    // KV (consultPrompt) or chain on its own, so this safely recovers from
+    // stuck states where the original POST died (e.g. function timeout).
+    let cancelled = false;
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
+    let elapsedMs = 0;
+    let recoveryFired = false;
+    const POLL_INTERVAL_MS = 4000;
+    const RECOVERY_AT_MS = 8000;
+    const GIVE_UP_AT_MS = 90_000;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/job/sanitize?jobId=${jobId}`);
+        if (cancelled) return;
+        if (res.ok) {
+          const d = await res.json();
+          if (d.safe === true) {
+            setSanitized(true);
+            return;
+          }
+          if (d.safe === false) {
+            setSanitized(false);
+            setSanitizeError(d.reason || "Job flagged for manual review");
+            return;
+          }
+          // d.safe === null/undefined → still pending
+        }
+        // Either non-OK response or pending: kick off recovery POST after a short wait
+        if (!recoveryFired && elapsedMs >= RECOVERY_AT_MS) {
+          recoveryFired = true;
+          fetch("/api/job/sanitize", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ jobId: String(jobId) }),
+          }).catch(() => {});
+        }
+        if (elapsedMs >= GIVE_UP_AT_MS) {
+          setSanitized(false);
+          setSanitizeError("Security review is taking longer than expected. Please refresh — if this persists, contact support.");
+          return;
+        }
+        elapsedMs += POLL_INTERVAL_MS;
+        pollTimer = setTimeout(poll, POLL_INTERVAL_MS);
+      } catch {
+        if (cancelled) return;
+        if (elapsedMs >= GIVE_UP_AT_MS) {
+          setSanitized(false);
+          setSanitizeError("Failed to verify job safety");
+          return;
+        }
+        elapsedMs += POLL_INTERVAL_MS;
+        pollTimer = setTimeout(poll, POLL_INTERVAL_MS);
+      }
+    };
+
+    poll();
+
+    return () => {
+      cancelled = true;
+      if (pollTimer) clearTimeout(pollTimer);
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [jobExists]);
+  }, [jobExists, jobId]);
 
   useEffect(() => {
     if (messages.length > 0) {


### PR DESCRIPTION
## Summary

When a sanitize POST died mid-call (function timeout, network blip, etc.) the chat page polled forever because nothing re-fired the POST and \`ChatClient\` only fetched once. UX: jobs looked permanently stuck. Job 114 today is exhibit A.

Two-part self-healing fix:

### 1. \`/api/job/sanitize\` POST is now self-sufficient

\`description\` is optional. If missing, the endpoint resolves it itself:

1. \`getConsultPrompt(jobId)\` — off-chain KV (svc 1, 2 posted via current flow)
2. Falls back to on-chain \`Job.description\` (build/audit/etc + pre-#41 consults)

Means any caller can retrigger sanitize with just \`{jobId}\` — no need to remember the original prompt. The \`cvAutoPass\` path still requires \`description\` (it's used at posting time and there's no off-chain or on-chain source for synthetic \`cv-{timestamp}\` jobs).

### 2. \`ChatClient\` polls + auto-recovers

Replaced single fetch with a poll loop:

- Every 4s: re-check status
- After 8s of pending state: fire recovery POST (no body except jobId — server resolves)
- After 90s total: surface "taking longer than expected, refresh or contact support" instead of infinite spinner

## Test plan

- [ ] Post a fresh consult → chat unblocks normally within ~2-5s (no regression)
- [ ] Kill sanitize manually (e.g. via Vercel logs) and watch ChatClient retry, recover within ~12s
- [ ] Visit \`/chat/114\` — should auto-recover via the recovery POST since the consultPrompt KV has the real prompt
- [ ] Job that legitimately fails sanitize (unsafe content) still surfaces the reason, not a generic timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)