### PR TITLE
fix(jobs): add svc 10 (Feature) to display map; remove dead Post Job link

### DIFF
--- a/packages/nextjs/app/jobs/[id]/JobDetailClient.tsx
+++ b/packages/nextjs/app/jobs/[id]/JobDetailClient.tsx
@@ -44,6 +44,7 @@ const SERVICE_NAMES: Record<number, string> = {
   7: "Research Report",
   8: "Judge / Oracle",
   9: "HumanQA",
+  10: "Feature",
 };
 
 const CONSULT_TYPES = new Set([1, 2]);

--- a/packages/nextjs/app/jobs/page.tsx
+++ b/packages/nextjs/app/jobs/page.tsx
@@ -29,6 +29,7 @@ const SERVICE_NAMES: Record<number, string> = {
   7: "Research Report",
   8: "Judge / Oracle",
   9: "HumanQA",
+  10: "Feature",
 };
 
 function JobCard({ jobId }: { jobId: number; publicBoard?: boolean }) {
@@ -114,7 +115,6 @@ export default function JobsPage() {
       <div className="flex flex-wrap gap-2 mb-6">
         <Link href="/consult" className="btn btn-primary btn-sm">💬 New Consult</Link>
         <Link href="/build" className="btn btn-outline btn-sm">🔨 New Build</Link>
-        <Link href="/post" className="btn btn-outline btn-sm">📝 Post Job</Link>
         <Link href="/" className="btn btn-ghost btn-sm">← Services</Link>
       </div>
 


### PR DESCRIPTION
## Summary

Two small things on the \`/jobs\` page:

1. \`SERVICE_NAMES\` in \`app/jobs/page.tsx\` and \`app/jobs/[id]/JobDetailClient.tsx\` was missing \`10: "Feature"\`. The on-chain contract supports it and \`/api/job/[id]/chat\` has had the full 1–10 map for a while — the listing/detail components just got missed. Fixed both. (Job #102 was the trigger — showed as "Unknown" in the dashboard.)
2. \`/jobs\` had a "📝 Post Job" link to \`/post\` — that route doesn't exist. Removed.

## Test plan

- [ ] Visit \`/jobs\` → job #102 (and any other svc 10 job) renders as "Feature" instead of "Unknown"
- [ ] Visit \`/jobs/102\` → service is "Feature"
- [ ] No "Post Job" button on \`/jobs\` page anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)