### PR TITLE
feat(consult): detect research requests, route to /research

### DIFF
--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -106,7 +106,7 @@ async function getAllServiceTypesFormatted(): Promise<string> {
       qa: "Frontend QA audit (UX, accessibility, functionality)",
       build: "Full build job — LeftClaw ships your project end-to-end",
       feature: "Add a feature, fix a bug, or update an existing project",
-      research: "Research report on any Ethereum/crypto topic",
+      research: "Research report on any technical, crypto-adjacent, or industry topic — AI/ML developments, ecosystem trends, security disclosures, market data, anything the client wants a structured deep-dive on",
       judge: "Scheduled oracle job — Clawd executes onchain when conditions are met",
       humanqa: "Direct human help — review your build, prod-readiness, deployment, anything the AI can't handle (short attention budget but real human time)",
     };
@@ -179,14 +179,14 @@ Static-frontend workarounds to design around when planning the build:
 - Be direct and opinionated. If their idea has a simpler or better approach, say it.
 - Ask ONE sharp clarifying question at a time. Never dump a wall of questions.
 - Show you understood their need by reflecting back the key aspect before asking.
-- **Listen for routing signals:** "audit", "security review", "check my contract", "review my code" → AI Audit. "QA", "test my dApp", "check my site", "quality" → QA Report. "image", "PFP", "profile picture", "avatar" → PFP Generator. "add a feature", "feature request", "update my project", "existing repo", "add to my repo", "build on top of", "bug fix", "fix a bug", "patch", "migration" → Feature. Human help with deployment, prod-readiness, backend, ENS, custom domain, or anything beyond a prototype → HumanQA. Wants to build something new → proceed with build consultation.
+- **Listen for routing signals:** "audit", "security review", "check my contract", "review my code" → AI Audit. "QA", "test my dApp", "check my site", "quality" → QA Report. "image", "PFP", "profile picture", "avatar" → PFP Generator. "add a feature", "feature request", "update my project", "existing repo", "add to my repo", "build on top of", "bug fix", "fix a bug", "patch", "migration" → Feature. "research", "look into", "investigate", "deep dive", "what's the latest on", "compare X vs Y", "report on", "find out", "when will X come out", or any open-ended information-gathering request (crypto OR adjacent — AI/ML, infra, market, security disclosures all in scope) → Research. Human help with deployment, prod-readiness, backend, ENS, custom domain, or anything beyond a prototype → HumanQA. Wants to build something new → proceed with build consultation.
 - **Listen for backend/production signals:** custodial logic, off-chain compute, email, push, cron, login/sessions, admin dashboards, private data, file uploads to private storage, custom domains, ENS. The MOMENT you hear any of these, flag the IPFS-only/no-backend constraint EARLY. Don't generate a plan that includes them — design around them or route to HumanQA.
 - After 1–2 exchanges, if it's clearly not a build, confirm with the user and route. Once confirmed, output the appropriate route marker.
 - When it IS a build, proceed with clarifying questions. When you have enough context (usually 5–10 exchanges), offer to generate the build plan.
 
 ## Opening Behavior (CRITICAL)
 When the client provides their initial context/idea:
-1. Read what they said carefully. Determine if they want to BUILD something, get an AUDIT, get a QA REPORT, generate a PFP, get human help (HUMANQA), update an existing project (FEATURE), or something else.
+1. Read what they said carefully. Determine if they want to BUILD something, get an AUDIT, get a QA REPORT, generate a PFP, get human help (HUMANQA), update an existing project (FEATURE), get a RESEARCH report on any topic (crypto OR adjacent — AI/ML, market, infra, security disclosures), or something else.
 2. If it's clearly a non-build service, acknowledge what they need and confirm before routing.
 3. If it's a build (or unclear), acknowledge the interesting or tricky part of what they want to build (1–2 sentences showing you got it), identify the single most important unknown, and ask that one question.
 
@@ -218,6 +218,10 @@ When the user confirms they want a non-build service, output the appropriate rou
 
 ---ROUTE: HUMANQA---
 [Brief description of what human help they need]
+---ROUTE END---
+
+---ROUTE: RESEARCH---
+[Brief description of the research topic — what the user wants investigated]
 ---ROUTE END---
 
 The route markers must be EXACTLY on their own lines. Only output a route marker AFTER the user confirms they want that service.

--- a/packages/nextjs/app/chat/[jobId]/ChatClient.tsx
+++ b/packages/nextjs/app/chat/[jobId]/ChatClient.tsx
@@ -71,7 +71,7 @@ export default function ChatPage() {
   const [planDescription, setPlanDescription] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [isStartingBuild, setIsStartingBuild] = useState(false);
-  const [routeSuggestion, setRouteSuggestion] = useState<{ type: "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA"; summary: string } | null>(null);
+  const [routeSuggestion, setRouteSuggestion] = useState<{ type: "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA" | "RESEARCH"; summary: string } | null>(null);
   const [planGenerations, setPlanGenerations] = useState(0);
   const MAX_PLAN_GENERATIONS = 3;
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -276,9 +276,9 @@ export default function ChatPage() {
       }
 
       // Check for route markers
-      const routeMatch = assistantContent.match(/---ROUTE:\s*(AUDIT|QA|PFP|BUILD|FEATURE|HUMANQA)---\s*([\s\S]*?)---ROUTE END---/);
+      const routeMatch = assistantContent.match(/---ROUTE:\s*(AUDIT|QA|PFP|BUILD|FEATURE|HUMANQA|RESEARCH)---\s*([\s\S]*?)---ROUTE END---/);
       if (routeMatch) {
-        setRouteSuggestion({ type: routeMatch[1] as "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA", summary: routeMatch[2].trim() });
+        setRouteSuggestion({ type: routeMatch[1] as "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA" | "RESEARCH", summary: routeMatch[2].trim() });
       }
     } catch (e) {
       setError("Network error");
@@ -524,6 +524,7 @@ export default function ChatPage() {
               else if (routeSuggestion.type === "PFP") router.push("/pfp");
               else if (routeSuggestion.type === "FEATURE") router.push("/post?type=feature");
               else if (routeSuggestion.type === "HUMANQA") router.push("/humanqa");
+              else if (routeSuggestion.type === "RESEARCH") router.push("/research");
             }}
           >
             {routeSuggestion.type === "AUDIT" && "🛡️ Go to Audit Service →"}
@@ -531,6 +532,7 @@ export default function ChatPage() {
             {routeSuggestion.type === "PFP" && "🦞 Generate My PFP →"}
             {routeSuggestion.type === "FEATURE" && "🔧 Go to Feature/Bug Fix →"}
             {routeSuggestion.type === "HUMANQA" && "👤 Talk to a Human →"}
+            {routeSuggestion.type === "RESEARCH" && "📚 Go to Research Report →"}
           </button>
         </div>
       )}

--- a/packages/nextjs/app/chat/x402/[sessionId]/X402ChatClient.tsx
+++ b/packages/nextjs/app/chat/x402/[sessionId]/X402ChatClient.tsx
@@ -51,7 +51,7 @@ export default function X402ChatClient() {
   const [planGistUrl, setPlanGistUrl] = useState<string | null>(null);
   const [planDescription, setPlanDescription] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [routeSuggestion, setRouteSuggestion] = useState<{ type: "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA"; summary: string } | null>(null);
+  const [routeSuggestion, setRouteSuggestion] = useState<{ type: "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA" | "RESEARCH"; summary: string } | null>(null);
   const [sigPending, setSigPending] = useState(false);
   const [sigError, setSigError] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -211,9 +211,9 @@ export default function X402ChatClient() {
         }
 
         // Check for route markers
-        const routeMatch = assistantContent.match(/---ROUTE:\s*(AUDIT|QA|PFP|BUILD|FEATURE|HUMANQA)---\s*([\s\S]*?)---ROUTE END---/);
+        const routeMatch = assistantContent.match(/---ROUTE:\s*(AUDIT|QA|PFP|BUILD|FEATURE|HUMANQA|RESEARCH)---\s*([\s\S]*?)---ROUTE END---/);
         if (routeMatch) {
-          setRouteSuggestion({ type: routeMatch[1] as "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA", summary: routeMatch[2].trim() });
+          setRouteSuggestion({ type: routeMatch[1] as "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA" | "RESEARCH", summary: routeMatch[2].trim() });
         }
       } catch {
         setChatError("Network error");
@@ -411,6 +411,7 @@ export default function X402ChatClient() {
               else if (routeSuggestion.type === "PFP") router.push("/pfp");
               else if (routeSuggestion.type === "FEATURE") router.push("/post?type=feature");
               else if (routeSuggestion.type === "HUMANQA") router.push("/humanqa");
+              else if (routeSuggestion.type === "RESEARCH") router.push("/research");
             }}
           >
             {routeSuggestion.type === "AUDIT" && "🛡️ Go to Audit Service →"}
@@ -418,6 +419,7 @@ export default function X402ChatClient() {
             {routeSuggestion.type === "PFP" && "🦞 Generate My PFP →"}
             {routeSuggestion.type === "FEATURE" && "🔧 Go to Feature/Bug Fix →"}
             {routeSuggestion.type === "HUMANQA" && "👤 Talk to a Human →"}
+            {routeSuggestion.type === "RESEARCH" && "📚 Go to Research Report →"}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary

The consult bot was hard-rejecting non-Web3 research asks like "when will Claude Opus 4.8 come out?" with "outside LeftClaw consultation scope" — but Research Report is an actual paid service (svc 7) and Opus is more than capable of doing it. Bot just didn't know to route there.

## Changes

**System prompt (\`api/chat/route.ts\`):**

- Added research routing signals to the listening list: \`"research", "look into", "investigate", "deep dive", "what's the latest on", "compare X vs Y", "report on", "find out", "when will X come out"\`, plus open-ended information-gathering. Crypto **or** adjacent — AI/ML, market data, infra, security disclosures all in scope.
- Added RESEARCH to the opening-behavior service determination list.
- Added a new \`---ROUTE: RESEARCH---\` marker section.
- Broadened the live service-catalog description from \`"Research report on any Ethereum/crypto topic"\` to \`"any technical, crypto-adjacent, or industry topic — AI/ML developments, ecosystem trends, security disclosures, market data, anything the client wants a structured deep-dive on"\`.

**Both ChatClient + X402ChatClient:**

- Extended the route type union to include \`"RESEARCH"\`
- Updated the route-marker regex
- Added \`router.push("/research")\` navigation
- Added the "📚 Go to Research Report →" CTA button label

No contract change, no new endpoint, no auth surface change.

## Test plan

- [ ] Open \`/chat/x402/...\` or any consult chat
- [ ] Ask: "i would like to research when claude opus 4.8 will come out" — bot should acknowledge and offer to route to research instead of rejecting as out-of-scope
- [ ] Confirm to route → "📚 Go to Research Report →" CTA appears → click → lands on \`/research\`
- [ ] Other routing signals (audit, qa, build, etc.) still work as before — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)