### PR TITLE
feat(consult): persist route CTA across reloads + close consult on route

### DIFF
--- a/packages/nextjs/app/chat/[jobId]/ChatClient.tsx
+++ b/packages/nextjs/app/chat/[jobId]/ChatClient.tsx
@@ -72,6 +72,34 @@ export default function ChatPage() {
   const [copied, setCopied] = useState(false);
   const [isStartingBuild, setIsStartingBuild] = useState(false);
   const [routeSuggestion, setRouteSuggestion] = useState<{ type: "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA" | "RESEARCH"; summary: string } | null>(null);
+  const routeStorageKey = `routeSuggestion-job-${jobId}`;
+
+  // Restore route suggestion from localStorage on mount (so the CTA button
+  // survives navigating away and coming back).
+  useEffect(() => {
+    if (typeof window === "undefined" || !jobId) return;
+    const saved = localStorage.getItem(routeStorageKey);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (parsed?.type && parsed?.summary) setRouteSuggestion(parsed);
+      } catch {
+        localStorage.removeItem(routeStorageKey);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jobId]);
+
+  // Persist any route suggestion change to localStorage.
+  useEffect(() => {
+    if (typeof window === "undefined" || !jobId) return;
+    if (routeSuggestion) {
+      localStorage.setItem(routeStorageKey, JSON.stringify(routeSuggestion));
+    } else {
+      localStorage.removeItem(routeStorageKey);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routeSuggestion, jobId]);
   const [planGenerations, setPlanGenerations] = useState(0);
   const MAX_PLAN_GENERATIONS = 3;
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -520,6 +548,19 @@ export default function ChatPage() {
             className="btn btn-primary btn-sm flex-1"
             onClick={() => {
               const desc = encodeURIComponent(routeSuggestion.summary || "");
+              // Close the on-chain consult job when the user routes to a
+              // downstream service. Mirrors the existing "Start Build Job"
+              // path. The sanitizer wallet is a registered worker; it calls
+              // completeJob() with a routing-result string as the resultCID.
+              if (isConsultation && address) {
+                const resultCID = `Routed to ${routeSuggestion.type.toLowerCase()}: ${routeSuggestion.summary || ""}`.slice(0, 500);
+                fetch("/api/job/close-consultation", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ jobId, resultCID, address }),
+                  keepalive: true,
+                }).catch(() => {});
+              }
               if (routeSuggestion.type === "AUDIT") router.push(`/audit?description=${desc}`);
               else if (routeSuggestion.type === "QA") router.push(`/qa?description=${desc}`);
               else if (routeSuggestion.type === "PFP") router.push(`/pfp?prompt=${desc}`);

--- a/packages/nextjs/app/chat/x402/[sessionId]/X402ChatClient.tsx
+++ b/packages/nextjs/app/chat/x402/[sessionId]/X402ChatClient.tsx
@@ -52,6 +52,34 @@ export default function X402ChatClient() {
   const [planDescription, setPlanDescription] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [routeSuggestion, setRouteSuggestion] = useState<{ type: "AUDIT" | "QA" | "PFP" | "BUILD" | "FEATURE" | "HUMANQA" | "RESEARCH"; summary: string } | null>(null);
+  const routeStorageKey = `routeSuggestion-x402-${sessionId}`;
+
+  // Restore route suggestion from localStorage on mount (so the CTA button
+  // survives navigating away and coming back).
+  useEffect(() => {
+    if (typeof window === "undefined" || !sessionId) return;
+    const saved = localStorage.getItem(routeStorageKey);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (parsed?.type && parsed?.summary) setRouteSuggestion(parsed);
+      } catch {
+        localStorage.removeItem(routeStorageKey);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]);
+
+  // Persist any route suggestion change to localStorage.
+  useEffect(() => {
+    if (typeof window === "undefined" || !sessionId) return;
+    if (routeSuggestion) {
+      localStorage.setItem(routeStorageKey, JSON.stringify(routeSuggestion));
+    } else {
+      localStorage.removeItem(routeStorageKey);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routeSuggestion, sessionId]);
   const [sigPending, setSigPending] = useState(false);
   const [sigError, setSigError] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -407,6 +435,15 @@ export default function X402ChatClient() {
             className="btn btn-primary btn-sm flex-1"
             onClick={() => {
               const desc = encodeURIComponent(routeSuggestion.summary || "");
+              // Mark this consult as closed when the user routes to a service
+              // (matches the pattern the build flow already uses). Fire-and-forget
+              // so navigation isn't blocked on the close response.
+              fetch(`/api/session/${sessionId}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ action: "close" }),
+                keepalive: true,
+              }).catch(() => {});
               if (routeSuggestion.type === "AUDIT") router.push(`/audit?description=${desc}`);
               else if (routeSuggestion.type === "QA") router.push(`/qa?description=${desc}`);
               else if (routeSuggestion.type === "PFP") router.push(`/pfp?prompt=${desc}`);


### PR DESCRIPTION
## Summary

Two related polish items on the consult handoff flow:

### 1. Route CTA now persists across reloads

The "📚 Go to Research Report →" / "🛡️ Audit Service →" / etc. button used to disappear if the user navigated away from the chat and came back — \`routeSuggestion\` was just React state. Now persisted to \`localStorage\` (keyed by \`sessionId\` for x402 sessions, \`jobId\` for on-chain consults), and restored on mount. Cleared automatically when the user clicks "Continue chatting".

### 2. Clicking the route CTA now closes the consult

Mirrors the pattern the "Start Build Job" button has used for a while: when the user routes to a downstream service, the consultation is finished. So we mark it complete:

- **x402 sessions:** POST \`/api/session/{id}\` with \`action: "close"\` (existing endpoint)
- **on-chain consults (svc 1, 2):** POST \`/api/job/close-consultation\` with \`resultCID\` = \`"Routed to {service}: {summary}"\`. The sanitizer wallet (already a registered worker) calls \`completeJob()\` on-chain so the user doesn't need to sign a tx.

Both fired \`keepalive\` fire-and-forget so navigation isn't blocked on the close response.

## Test plan

- [ ] Open consult → bot suggests routing → "📚 Go to Research Report →" appears
- [ ] Reload the page → button is still there (localStorage hit)
- [ ] Navigate to /jobs and back to chat → still there
- [ ] Click the CTA → land on /research with description prefilled, AND consult job/session is now marked completed
- [ ] Visit /jobs/{N} for the just-routed consult → status shows Completed, resultCID = "Routed to research: …"
- [ ] Click "Continue chatting" instead → CTA disappears, consult stays active

🤖 Generated with [Claude Code](https://claude.com/claude-code)