### PR TITLE
fix(consult): drop auto-timeout from 24h to 2h

### DIFF
--- a/packages/nextjs/app/api/job/consult-timeout/route.ts
+++ b/packages/nextjs/app/api/job/consult-timeout/route.ts
@@ -1,8 +1,8 @@
 /**
  * Cron-able endpoint to auto-timeout stale consultation jobs.
  *
- * - OPEN consultations older than 24h → COMPLETED
- * - IN_PROGRESS consultations older than 24h → COMPLETED
+ * - OPEN consultations older than 2h → COMPLETED
+ * - IN_PROGRESS consultations older than 2h → COMPLETED
  *
  * POST /api/job/consult-timeout
  */
@@ -16,8 +16,8 @@ import deployedContracts from "~~/contracts/deployedContracts";
 const { address, abi } = deployedContracts[8453].LeftClawServicesV2;
 
 const CONSULTATION_TYPE_IDS = [1, 2]; // Quick Consultation, Deep Consultation
-const OPEN_TIMEOUT_HOURS = 24;
-const IN_PROGRESS_TIMEOUT_HOURS = 24;
+const OPEN_TIMEOUT_HOURS = 2;
+const IN_PROGRESS_TIMEOUT_HOURS = 2;
 const TIMEOUT_RESULT_URL = "https://leftclaw.services/consult-timeout";
 
 // Simple auth key — set CONSULT_TIMEOUT_SECRET env var to protect this endpoint


### PR DESCRIPTION
## Summary
- Lowers consult-timeout cron threshold from 24h → 2h for both OPEN and IN_PROGRESS consultations.
- Stale consultations were sitting IN_PROGRESS for a full day before the hourly sweep would close them; 2h is plenty for an abandoned session.

## Test plan
- [ ] Vercel cron `/api/job/consult-timeout` continues to fire hourly
- [ ] Next run sweeps any IN_PROGRESS consultations >2h old to COMPLETED with the existing timeout result URL
- [ ] No regression to non-consultation jobs (serviceTypeId filter still gates to types 1 and 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)