### PR TITLE
fix(consult): hard-cap consultation chats at 15 user messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ x402 payments go to a sanitizer wallet which calls `postJobFor()` on-chain, auto
 | Service | Slug | Price | Description |
 |---|---|---|---|
 | Quick Consult | `consult` | $20 | 15-message focused Q&A → build plan |
-| Deep Consult | `consult-deep` | $30 | 30-message architecture deep-dive |
+| Deep Consult | `consult-deep` | $30 | Architecture deep-dive chat |
 | PFP Generator | `pfp` | $0.25 | AI-generated profile picture |
 | Contract Audit | `audit` | $200 | Smart contract security review |
 | Frontend QA Audit | `qa` | $50 | Pre-ship quality review |

--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -323,7 +323,7 @@ export async function POST(req: NextRequest) {
   }
 
   // Message limits + rate limiting for job-based chats
-  // Consultations: enforce message limits (Quick=15, Deep=30)
+  // Consultations: hard cap at 15 user messages (both Quick and Deep)
   // Other jobs: rate limit (3/hr active, 2 total post-completion)
   let jobMessageLimit = 0;
   let jobUserMessageCount = 0;
@@ -341,13 +341,20 @@ export async function POST(req: NextRequest) {
       const isConsultation = serviceTypeId === 1 || serviceTypeId === 2;
 
       if (isConsultation) {
-        // Infinite consultation messages — no server-side limit enforced
-        // (client-side tracking in ChatClient.tsx shows usage but never blocks)
-        jobMessageLimit = 9999;
+        // Hard cap at 15 user messages for both Quick and Deep to prevent
+        // runaway Opus costs from idle/abandoned-but-still-typing sessions.
+        // Plan generation bypasses the cap so users can still finalize a plan
+        // after hitting the limit.
+        jobMessageLimit = 15;
         const existingMessages = await getJobMessages(String(jobId));
         jobUserMessageCount = existingMessages.filter(m => m.role === "user").length;
 
-        // Never block based on message count — always allow
+        if (jobUserMessageCount >= jobMessageLimit && !isPlanGeneration) {
+          return new Response(
+            JSON.stringify({ error: "Message limit reached", messagesUsed: jobUserMessageCount, messagesLimit: jobMessageLimit }),
+            { status: 403 },
+          );
+        }
       } else {
         const rl = checkRateLimit(String(jobId), clientAddress, Number(job.status));
         if (!rl.allowed) {

--- a/packages/nextjs/app/api/consult/deep/route.ts
+++ b/packages/nextjs/app/api/consult/deep/route.ts
@@ -41,7 +41,7 @@ export const POST = withX402DynamicSettleFirst(
       network: BASE_NETWORK,
       payTo: PAYMENT_ADDRESS,
     },
-    description: "Deep Consultation — 30-message deep-dive on architecture, protocol design, or strategy",
+    description: "Deep Consultation — deep-dive on architecture, protocol design, or strategy",
     extensions: {
       ...declareDiscoveryExtension({
         input: { description: "What you need help with", context: "optional context" },

--- a/packages/nextjs/app/api/services/route.ts
+++ b/packages/nextjs/app/api/services/route.ts
@@ -38,7 +38,7 @@ export async function GET() {
         endpoint: "/api/consult/deep",
         method: "POST",
         name: "Deep Consultation",
-        description: "A 30-message deep-dive on complex architecture, protocol design, or strategy.",
+        description: "A deep-dive chat on complex architecture, protocol design, or strategy.",
         price: consultDeep,
         responseType: "session",
       },

--- a/packages/nextjs/app/chat/[jobId]/ChatClient.tsx
+++ b/packages/nextjs/app/chat/[jobId]/ChatClient.tsx
@@ -121,7 +121,7 @@ export default function ChatPage() {
   // Message limit tracking for consultations
   const serviceTypeId = job ? Number((job as any).serviceTypeId ?? (job as any).serviceType ?? 0) : 0;
   const isConsultation = serviceTypeId === 1 || serviceTypeId === 2;
-  const maxMessages = 9999; // TEMP: no limit during testing
+  const maxMessages = 15;
   const userMessageCount = messages.filter(m => m.role === "user").length;
   const [serverMsgUsed, setServerMsgUsed] = useState<number | null>(null);
   // Use server count when available (more accurate), otherwise client count
@@ -487,7 +487,7 @@ export default function ChatPage() {
               }`}>
                 {isAtLimit
                   ? "🚫 Limit reached"
-                  : `💬 ${displayedUsed} / ∞`
+                  : `💬 ${displayedUsed} / ${maxMessages}`
                 }
               </span>
             )}


### PR DESCRIPTION
## Summary
Re-adds the hard cap on consultation chats: **15 user messages, flat** for both Quick and Deep. Plan generation bypasses the cap so users can still finalize a plan after hitting it. Also drops the stale "30-message" framing from the Deep Consultation discovery extension copy.

## Why now
Diagnosis of last night's Opus 4.7 cost spike:

1. **Mar 30** (\`919bc95\`): client-side cap killed with comment \`// TEMP: no limit during testing\` — never restored
2. **Mar 31** (\`1fa17bb\`): server-side 15/30 enforcement removed
3. **May 7** (\`2d3a3a6\`): consultation chat upgraded from Opus 4.6 → 4.7

The combination = a single client could chat overnight on Opus 4.7 with no per-session cap. The hourly auto-timeout was 24h (already lowered to 2h in #53), but an actively typing client wouldn't trip it.

## What's enforced
- Server (\`api/chat/route.ts\`): returns 403 \`Message limit reached\` when user message count hits 15, unless \`isPlanGeneration=true\`
- Client (\`ChatClient.tsx\`): counter shows \`💬 N / 15\` and the input flips to "🚫 Limit reached" at 15
- Deep Consultation discovery copy (\`api/consult/deep/route.ts\`) updated: dropped "30-message" prefix, kept the "deep-dive on architecture..." framing so the value prop now leans on depth rather than raw count

## Companion PRs from the same triage
- #53 (merged): drop consult auto-timeout 24h → 2h
- #55: drop consult chat + per-job PM chat model from Opus 4.7 → Sonnet 4.6

## Test plan
- [ ] Open a Quick consult, send 15 messages — 16th should return 403 "Message limit reached"
- [ ] At 15/15, click "Generate plan" — should succeed (bypasses cap up to 3 plans)
- [ ] UI shows \`💬 N / 15\` counter, flips to "🚫 Limit reached" at 15
- [ ] Deep Consultation discovery payload no longer advertises "30-message"

🤖 Generated with [Claude Code](https://claude.com/claude-code)