### PR TITLE
chore(model): drop consult chat + per-job PM chat from Opus 4.7 → Sonnet 4.6

### DIFF
--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -462,7 +462,7 @@ export async function POST(req: NextRequest) {
       "X-API-Key": apiKey,
     },
     body: JSON.stringify({
-      model: "claude-opus-4.7",
+      model: "claude-sonnet-4.6",
       max_tokens: 4096,
       system: systemPrompt,
       stream: true,

--- a/packages/nextjs/app/api/job/[id]/chat/route.ts
+++ b/packages/nextjs/app/api/job/[id]/chat/route.ts
@@ -484,7 +484,7 @@ You can use your tools to read additional repo files, answer escalations, or req
 
   for (let i = 0; i < maxIterations; i++) {
     const response = await anthropic.messages.create({
-      model: "claude-opus-4.7",
+      model: "claude-sonnet-4.6",
       max_tokens: 2000,
       system: systemPrompt,
       tools,


### PR DESCRIPTION
## Summary
Switch both Bankr-proxied chat endpoints from \`claude-opus-4.7\` → \`claude-sonnet-4.6\`:
- \`/api/chat\` — the consultation chat (LeftClaw triage / clarifying questions / plan output)
- \`/api/job/[id]/chat\` — the per-job PM chat (tool-use loop, up to 5 iterations per turn)

Per-token cost drops ~5x on both. Both routes were already on Sonnet 4.6 until commit \`2d3a3a6\` bumped them to Opus 4.7 on May 7.

## Why
Part of the overnight Opus 4.7 cost spike triage. Neither route is where Opus earns its premium:

- **Consult chat** is mostly routing decisions, clarifying questions, and a final structured plan emit (when the user explicitly hits "generate plan"). The system prompt is prescriptive; Sonnet handles this fine.
- **Per-job PM chat** runs a tool-use loop up to 5 iterations per turn (\`read_file\`, \`answer_escalation\`, \`fetch_url\`, \`fetch_ethskill\`, \`request_stage_rollback\`). Every iteration re-bills the full system prompt (job context + work logs + plan + history + skill docs). That's the biggest cost-amplification surface in the codebase — 5x worse than a single-shot call. This is "look something up, answer the client" work, not deep reasoning.

Sanitize was already rolled back to Sonnet 4.6 for the same reason in #46.

## Companion PRs from the same triage
- #53 (merged): drop consult auto-timeout 24h → 2h
- #54: re-add hard 15-message cap on consult chats + drop "30-message" framing from Deep discovery copy

## Test plan
- [ ] Open a Quick consult, confirm streaming + routing still works (consult chat)
- [ ] Trigger \`---PLAN START---\` / \`---PLAN END---\` plan generation on consult chat — format intact
- [ ] On an in-progress build job, hit the PM chat with a question that triggers a tool-use (e.g. "what's in PLAN.md?" — exercises \`read_file\`)
- [ ] Watch the 24h cost window after deploy — both consult-chat and job-chat spend should drop sharply

🤖 Generated with [Claude Code](https://claude.com/claude-code)